### PR TITLE
feat: add Go, Java, TypeScript, and .NET client skeletons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,102 @@
+# ---------- OS / editor ----------
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+*.iml
+.project
+.classpath
+.settings/
+
+# ---------- Secrets / env ----------
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+credentials.json
+secrets.yaml
+
+# ---------- Logs ----------
+*.log
+logs/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# ---------- Python (neo_api_client) ----------
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+*.egg
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+MANIFEST
+.venv/
+venv/
+env/
+ENV/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.coverage
+htmlcov/
+.cache
+
+# ---------- Go (client/go-client) ----------
+client/go-client/bin/
+client/go-client/pkg/
+*.exe
+*.exe~
+*.test
+*.out
+vendor/
+
+# ---------- Node / TypeScript (client/typescript-client) ----------
+node_modules/
+client/typescript-client/node_modules/
+client/typescript-client/dist/
+client/typescript-client/*.tsbuildinfo
+.npm/
+.yarn/
+
+# ---------- .NET (client/dotnet-client) ----------
+client/dotnet-client/**/bin/
+client/dotnet-client/**/obj/
+*.user
+*.suo
+*.userprefs
+.vs/
+
+# ---------- Java / Maven (client/java-client) ----------
+client/java-client/target/
+*.class
+*.jar
+*.war
+*.ear
+*.nar
+hs_err_pid*
+dependency-reduced-pom.xml
+
+# ---------- Misc ----------
+*.bak
+*.tmp
+*.orig

--- a/client/README.md
+++ b/client/README.md
@@ -11,7 +11,7 @@ This folder ships four language ports of the reference Python SDK (`neo_api_clie
 
 ## Feature parity matrix
 
-All four clients expose the same methods that the Python SDK does. Method names are adjusted to the idiom of each language (`snake_case` in Python/TypeScript, `camelCase` in Java, `PascalCase` in Go/.NET).
+All four clients expose the same methods that the Python SDK does. Method names are adjusted to the idiom of each language (`snake_case` in Python, `camelCase` in TypeScript/Java, `PascalCase` in Go/.NET).
 
 
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,31 @@
+# Kotak Neo API — Multi-language Clients
+
+This folder ships four language ports of the reference Python SDK (`neo_api_client/` at the repo root). Each port offers the same public surface — a single `NeoAPI` / `NeoApi` class that speaks to Kotak Neo's REST and WebSocket endpoints.
+
+| Client | Path | Language | Build tool |
+|---|---|---|---|
+| Go | [`go-client/`](./go-client) | Go 1.21+ | `go build` |
+| Java | [`java-client/`](./java-client) | Java 17+ | Maven |
+| TypeScript | [`typescript-client/`](./typescript-client) | Node 18+ / TypeScript 5 | npm |
+| .NET | [`dotnet-client/`](./dotnet-client) | .NET 8 | `dotnet` CLI |
+
+## Feature parity matrix
+
+All four clients expose the same methods that the Python SDK does. Method names are adjusted to the idiom of each language (`snake_case` in Python/TypeScript, `camelCase` in Java, `PascalCase` in Go/.NET).
+
+
+
+## Shared semantics
+
+- **Environment**: every client takes `"prod"` or `"uat"` and routes to the matching base URL.
+- **Auth**: 2-step TOTP (login → validate) stores `editToken`, `sid`, `rid`, `serverId` in a per-instance Configuration.
+- **Headers**: `Sid`, `Auth`, `neo-fin-key`, and `Authorization` (consumer key) mirror the Python wire contract.
+- **Request bodies**: order/modify/cancel endpoints send `application/x-www-form-urlencoded` with a `jData` field, matching Python.
+- **Responses**: kept loose (`map[string]any` / `JsonObject` / `any` / `JsonElement`) to match Python's dict contract — callers parse fields they care about.
+
+## Reference
+
+- Python source: `../neo_api_client/`
+- Endpoint docs: `../docs/`
+
+Each subfolder has its own README with a quickstart. The Python SDK remains the source-of-truth; if the wire contract changes in `neo_api_client/`, port the change to all four clients.

--- a/client/dotnet-client/NeoApi.Examples/NeoApi.Examples.csproj
+++ b/client/dotnet-client/NeoApi.Examples/NeoApi.Examples.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>Kotak.Neo.Examples</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NeoApi\NeoApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/client/dotnet-client/NeoApi.Examples/Program.cs
+++ b/client/dotnet-client/NeoApi.Examples/Program.cs
@@ -1,0 +1,26 @@
+using Kotak.Neo;
+
+string env = Environment.GetEnvironmentVariable("NEO_ENV") ?? "uat";
+string consumer = Environment.GetEnvironmentVariable("NEO_CONSUMER") ?? "";
+string? mobile = Environment.GetEnvironmentVariable("NEO_MOBILE");
+string? ucc = Environment.GetEnvironmentVariable("NEO_UCC");
+string? totp = Environment.GetEnvironmentVariable("NEO_TOTP");
+string? mpin = Environment.GetEnvironmentVariable("NEO_MPIN");
+
+using var client = new NeoApi(environment: env, consumerKey: consumer);
+
+client.OnOpen += m => Console.WriteLine($"[ws] open : {m}");
+client.OnMessage += m => Console.WriteLine($"[ws] msg  : {m}");
+client.OnError += e => Console.WriteLine($"[ws] err  : {e.Message}");
+client.OnClose += m => Console.WriteLine($"[ws] close: {m}");
+
+if (string.IsNullOrEmpty(mobile) || string.IsNullOrEmpty(ucc) || string.IsNullOrEmpty(totp) || string.IsNullOrEmpty(mpin))
+{
+    Console.WriteLine("Set NEO_MOBILE, NEO_UCC, NEO_TOTP, NEO_MPIN to exercise login.");
+    Console.WriteLine("Client constructed OK; skipping live calls.");
+    return;
+}
+
+Console.WriteLine("totp_login: " + await client.TotpLoginAsync(mobile, ucc, totp));
+Console.WriteLine("totp_validate: " + await client.TotpValidateAsync(mpin));
+Console.WriteLine("order_report: " + await client.OrderReportAsync());

--- a/client/dotnet-client/NeoApi.sln
+++ b/client/dotnet-client/NeoApi.sln
@@ -1,0 +1,22 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NeoApi", "NeoApi\NeoApi.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NeoApi.Examples", "NeoApi.Examples\NeoApi.Examples.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/client/dotnet-client/NeoApi/Api/LoginApi.cs
+++ b/client/dotnet-client/NeoApi/Api/LoginApi.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using Kotak.Neo.Rest;
+
+namespace Kotak.Neo.Api;
+
+public class LoginApi
+{
+    private readonly RestClient _rest;
+    private readonly Configuration _config;
+
+    public LoginApi(RestClient rest, Configuration config)
+    {
+        _rest = rest;
+        _config = config;
+    }
+
+    public async Task<JsonElement> TotpLoginAsync(string mobileNumber, string ucc, string totp, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(mobileNumber) || string.IsNullOrEmpty(ucc) || string.IsNullOrEmpty(totp))
+        {
+            return JsonDocument.Parse("""{"error":[{"message":"mobile_number, ucc or totp missing"}]}""").RootElement.Clone();
+        }
+
+        var host = _config.Host.Trim().ToLowerInvariant();
+        var path = host == "prod" ? Urls.ProdPaths["totp_login"] : Urls.UatPaths["totp_login"];
+        var url = $"{Urls.BaseUrl.TrimEnd('/')}/{path}";
+
+        var (status, data, _) = await _rest.RequestAsync(
+            "POST", url,
+            headers: new Dictionary<string, string>
+            {
+                ["Authorization"] = _config.ConsumerKey ?? "",
+                ["neo-fin-key"] = _config.GetNeoFinKey(),
+                ["Content-Type"] = "application/json",
+            },
+            body: new { mobileNumber, ucc, totp },
+            ct: ct);
+
+        if (status is >= 200 and <= 299 && data.TryGetProperty("data", out var inner))
+        {
+            if (inner.TryGetProperty("token", out var tok)) _config.ViewToken = tok.GetString();
+            if (inner.TryGetProperty("sid", out var sid)) _config.Sid = sid.GetString();
+        }
+        return data;
+    }
+
+    public async Task<JsonElement> TotpValidateAsync(string mpin, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(mpin))
+            return JsonDocument.Parse("""{"error":[{"message":"Mpin is missing"}]}""").RootElement.Clone();
+
+        var host = _config.Host.Trim().ToLowerInvariant();
+        var path = host == "prod" ? Urls.ProdPaths["totp_validate"] : Urls.UatPaths["totp_validate"];
+        var url = $"{Urls.BaseUrl.TrimEnd('/')}/{path}";
+
+        var (status, data, _) = await _rest.RequestAsync(
+            "POST", url,
+            headers: new Dictionary<string, string>
+            {
+                ["Authorization"] = _config.ConsumerKey ?? "",
+                ["sid"] = _config.Sid ?? "",
+                ["Auth"] = _config.ViewToken ?? "",
+                ["neo-fin-key"] = _config.GetNeoFinKey(),
+                ["Content-Type"] = "application/json",
+            },
+            body: new { mpin },
+            ct: ct);
+
+        if (status is >= 200 and <= 299 && data.TryGetProperty("data", out var inner))
+        {
+            if (inner.TryGetProperty("token", out var tok)) _config.EditToken = tok.GetString();
+            if (inner.TryGetProperty("sid", out var sid)) _config.EditSid = sid.GetString();
+            if (inner.TryGetProperty("rid", out var rid)) _config.EditRid = rid.GetString();
+            if (inner.TryGetProperty("hsServerId", out var srv)) _config.ServerId = srv.GetString();
+            if (inner.TryGetProperty("dataCenter", out var dc)) _config.DataCenter = dc.GetString();
+            if (inner.TryGetProperty("baseUrl", out var bu)) _config.BaseUrl = bu.GetString();
+        }
+        return data;
+    }
+}

--- a/client/dotnet-client/NeoApi/Api/MarginApi.cs
+++ b/client/dotnet-client/NeoApi/Api/MarginApi.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Kotak.Neo.Models;
+using Kotak.Neo.Rest;
+using Kotak.Neo.Validation;
+
+namespace Kotak.Neo.Api;
+
+public class MarginApi
+{
+    private readonly RestClient _rest;
+    private readonly Configuration _config;
+
+    public MarginApi(RestClient rest, Configuration config)
+    {
+        _rest = rest;
+        _config = config;
+    }
+
+    public async Task<JsonElement> MarginRequiredAsync(MarginRequiredRequest r, CancellationToken ct = default)
+    {
+        Validators.ValidateMargin(r.ExchangeSegment, r.Price, r.OrderType, r.Product,
+            r.Quantity, r.InstrumentToken, r.TransactionType);
+
+        var (_, data, _) = await _rest.RequestAsync("POST",
+            _config.GetUrl("margin"),
+            queryParams: new Dictionary<string, string> { ["sId"] = _config.ServerId ?? "" },
+            headers: new Dictionary<string, string>
+            {
+                ["Sid"] = _config.EditSid ?? "",
+                ["Auth"] = _config.EditToken ?? "",
+                ["Content-Type"] = "application/x-www-form-urlencoded",
+            },
+            body: new Dictionary<string, object?>
+            {
+                ["exSeg"] = Settings.ExchangeSegment[r.ExchangeSegment],
+                ["prc"] = r.Price,
+                ["prcTp"] = Settings.OrderType[r.OrderType],
+                ["prod"] = Settings.Product[r.Product],
+                ["qty"] = r.Quantity,
+                ["tok"] = r.InstrumentToken,
+                ["trnsTp"] = r.TransactionType,
+                ["trgPrc"] = r.TriggerPrice,
+                ["brkName"] = r.BrokerName ?? "KOTAK",
+                ["brnchId"] = r.BranchId ?? "ONLINE",
+                ["slAbsOrTks"] = r.StopLossType,
+                ["slVal"] = r.StopLossValue,
+                ["sqrOffAbsOrTks"] = r.SquareOffType,
+                ["sqrOffVal"] = r.SquareOffValue,
+                ["trailSL"] = r.TrailingStopLoss,
+                ["tSLTks"] = r.TrailingSLValue,
+            }, ct: ct);
+        return JsonDocument.Parse(JsonSerializer.Serialize(new { data })).RootElement.Clone();
+    }
+}

--- a/client/dotnet-client/NeoApi/Api/OrderApi.cs
+++ b/client/dotnet-client/NeoApi/Api/OrderApi.cs
@@ -1,0 +1,246 @@
+using System.Text.Json;
+using Kotak.Neo.Models;
+using Kotak.Neo.Rest;
+using Kotak.Neo.Validation;
+
+namespace Kotak.Neo.Api;
+
+public class OrderApi
+{
+    private readonly RestClient _rest;
+    private readonly Configuration _config;
+
+    public OrderApi(RestClient rest, Configuration config)
+    {
+        _rest = rest;
+        _config = config;
+    }
+
+    private Dictionary<string, string> AuthHeaders(string contentType) => new()
+    {
+        ["Sid"] = _config.EditSid ?? "",
+        ["Auth"] = _config.EditToken ?? "",
+        ["Content-Type"] = contentType,
+    };
+
+    private Dictionary<string, string> ServerIdQuery() =>
+        new() { ["sId"] = _config.ServerId ?? "" };
+
+    public async Task<JsonElement> PlaceOrderAsync(PlaceOrderRequest r, CancellationToken ct = default)
+    {
+        Validators.ValidatePlaceOrder(r.ExchangeSegment, r.Product, r.Price, r.OrderType,
+            r.Quantity, r.Validity, r.TradingSymbol, r.TransactionType);
+
+        var body = new Dictionary<string, object?>
+        {
+            ["am"] = r.AMO ?? "NO",
+            ["dq"] = r.DisclosedQuantity ?? "0",
+            ["es"] = Settings.ExchangeSegment[r.ExchangeSegment],
+            ["mp"] = r.MarketProtection ?? "0",
+            ["pc"] = Settings.Product[r.Product],
+            ["pf"] = r.PF ?? "N",
+            ["pr"] = r.Price,
+            ["pt"] = Settings.OrderType[r.OrderType],
+            ["qt"] = r.Quantity,
+            ["rt"] = r.Validity,
+            ["tp"] = r.TriggerPrice ?? "0",
+            ["ts"] = r.TradingSymbol,
+            ["tt"] = r.TransactionType,
+            ["ig"] = r.Tag,
+            ["tk"] = r.ScripToken,
+            ["sot"] = r.SquareOffType,
+            ["slt"] = r.StopLossType,
+            ["slv"] = r.StopLossValue,
+            ["sov"] = r.SquareOffValue,
+            ["lat"] = r.LastTradedPrice,
+            ["tlt"] = r.TrailingStopLoss,
+            ["tsv"] = r.TrailingSLValue,
+            ["os"] = Settings.OrderSource,
+        };
+
+        var (_, data, _) = await _rest.RequestAsync("POST",
+            _config.GetUrl("place_order"),
+            queryParams: ServerIdQuery(),
+            headers: AuthHeaders("application/x-www-form-urlencoded"),
+            body: body, ct: ct);
+        return data;
+    }
+
+    public Task<JsonElement> CancelOrderAsync(string orderId, string amo = "NO", bool verify = false, CancellationToken ct = default)
+        => CancelEndpointAsync("cancel_order", orderId, amo, verify, ct);
+
+    public Task<JsonElement> CancelCoverOrderAsync(string orderId, string amo = "NO", bool verify = false, CancellationToken ct = default)
+        => CancelEndpointAsync("cancel_cover_order", orderId, amo, verify, ct);
+
+    public Task<JsonElement> CancelBracketOrderAsync(string orderId, string amo = "NO", bool verify = false, CancellationToken ct = default)
+        => CancelEndpointAsync("cancel_bracket_order", orderId, amo, verify, ct);
+
+    private async Task<JsonElement> CancelEndpointAsync(string endpoint, string orderId, string amo, bool verify, CancellationToken ct)
+    {
+        Validators.ValidateCancelOrder(orderId);
+        if (verify)
+        {
+            var book = await OrderReportAsync(ct).ConfigureAwait(false);
+            if (book.TryGetProperty("data", out var arr) && arr.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var row in arr.EnumerateArray())
+                {
+                    if (row.TryGetProperty("nOrdNo", out var nOrd) && nOrd.GetString() == orderId)
+                    {
+                        if (row.TryGetProperty("ordSt", out var st))
+                        {
+                            var s = st.GetString();
+                            if (s is "rejected" or "cancelled" or "complete" or "traded")
+                            {
+                                if (s == "complete") s = "Traded";
+                                return JsonDocument.Parse(JsonSerializer.Serialize(new
+                                {
+                                    Error = $"The Given Order Status is {s}",
+                                    Reason = row.TryGetProperty("rejRsn", out var rr) ? rr.GetString() : null,
+                                })).RootElement.Clone();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        var body = new Dictionary<string, object?> { ["on"] = orderId, ["am"] = amo };
+        var (_, data, _) = await _rest.RequestAsync("POST",
+            _config.GetUrl(endpoint),
+            queryParams: ServerIdQuery(),
+            headers: AuthHeaders("application/x-www-form-urlencoded"),
+            body: body, ct: ct);
+        return data;
+    }
+
+    public async Task<JsonElement> ModifyOrderAsync(ModifyOrderRequest r, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(r.OrderId))
+            throw new Exceptions.ApiValueError("order_id is mandatory");
+
+        var body = new Dictionary<string, object?>
+        {
+            ["tk"] = r.InstrumentToken,
+            ["mp"] = r.MarketProtection ?? "0",
+            ["pc"] = r.Product,
+            ["dd"] = r.DD ?? "NA",
+            ["dq"] = r.DisclosedQuantity ?? "0",
+            ["vd"] = r.Validity,
+            ["ts"] = r.TradingSymbol,
+            ["tt"] = r.TransactionType,
+            ["pr"] = r.Price,
+            ["pt"] = r.OrderType,
+            ["fq"] = r.FilledQuantity ?? "0",
+            ["tp"] = r.TriggerPrice ?? "0",
+            ["qt"] = r.Quantity,
+            ["no"] = r.OrderId,
+            ["es"] = r.ExchangeSegment,
+            ["am"] = r.AMO ?? "NO",
+            ["os"] = Settings.OrderSource,
+        };
+
+        var hasAll = !string.IsNullOrEmpty(r.InstrumentToken)
+            && !string.IsNullOrEmpty(r.ExchangeSegment)
+            && !string.IsNullOrEmpty(r.TradingSymbol)
+            && !string.IsNullOrEmpty(r.Product);
+
+        if (hasAll)
+        {
+            body["es"] = Settings.ExchangeSegment[r.ExchangeSegment!];
+            body["pc"] = Settings.Product[r.Product!];
+            body["pt"] = Settings.OrderType[r.OrderType];
+        }
+        else
+        {
+            var book = await OrderReportAsync(ct).ConfigureAwait(false);
+            if (!book.TryGetProperty("data", out var arr) || arr.ValueKind != JsonValueKind.Array)
+                return JsonDocument.Parse("""{"Message":"There is no Data in the Order Book"}""").RootElement.Clone();
+
+            var match = arr.EnumerateArray().FirstOrDefault(row =>
+                row.TryGetProperty("nOrdNo", out var n) && n.GetString() == r.OrderId);
+            if (match.ValueKind != JsonValueKind.Object)
+                return JsonDocument.Parse(JsonSerializer.Serialize(new
+                {
+                    Message = $"The Given Order Number {r.OrderId} is not matching with any of the orders"
+                })).RootElement.Clone();
+
+            if (match.TryGetProperty("ordSt", out var st))
+            {
+                var s = st.GetString();
+                if (s is "rejected" or "cancelled" or "complete" or "traded")
+                {
+                    if (s == "complete") s = "Traded";
+                    return JsonDocument.Parse(JsonSerializer.Serialize(new
+                    {
+                        Error = $"The Given Order Status is {s}, So we can't proceed further",
+                        Reason = match.TryGetProperty("rejRsn", out var rr) ? rr.GetString() : null,
+                    })).RootElement.Clone();
+                }
+            }
+
+            body["ts"] = string.IsNullOrEmpty(r.TradingSymbol) && match.TryGetProperty("trdSym", out var ts) ? ts.GetString() : r.TradingSymbol;
+            body["tk"] = string.IsNullOrEmpty(r.InstrumentToken) && match.TryGetProperty("tok", out var tk) ? tk.GetString() : r.InstrumentToken;
+            body["pc"] = string.IsNullOrEmpty(r.Product) && match.TryGetProperty("prod", out var pr) ? pr.GetString() : r.Product;
+            body["tt"] = string.IsNullOrEmpty(r.TransactionType) && match.TryGetProperty("trnsTp", out var tt) ? tt.GetString() : r.TransactionType;
+            body["es"] = string.IsNullOrEmpty(r.ExchangeSegment) && match.TryGetProperty("exSeg", out var es) ? es.GetString() : r.ExchangeSegment;
+            if ((r.TriggerPrice ?? "0") == "0" && match.TryGetProperty("trgPrc", out var tp))
+                body["tp"] = tp.GetString();
+        }
+
+        var (_, data, _) = await _rest.RequestAsync("POST",
+            _config.GetUrl("modify_order"),
+            queryParams: ServerIdQuery(),
+            headers: AuthHeaders("application/x-www-form-urlencoded"),
+            body: body, ct: ct);
+        return data;
+    }
+
+    public async Task<JsonElement> OrderReportAsync(CancellationToken ct = default)
+    {
+        var headers = AuthHeaders("application/x-www-form-urlencoded");
+        headers["accept"] = "application/json";
+        var (_, data, _) = await _rest.RequestAsync("GET",
+            _config.GetUrl("order_book"),
+            queryParams: ServerIdQuery(),
+            headers: headers, ct: ct);
+        return data;
+    }
+
+    public async Task<JsonElement> OrderHistoryAsync(string orderId, CancellationToken ct = default)
+    {
+        Validators.ValidateOrderHistory(orderId);
+        var (_, data, _) = await _rest.RequestAsync("POST",
+            _config.GetUrl("order_history"),
+            queryParams: ServerIdQuery(),
+            headers: AuthHeaders("application/x-www-form-urlencoded"),
+            body: new Dictionary<string, object?> { ["nOrdNo"] = orderId }, ct: ct);
+        return data;
+    }
+
+    public async Task<JsonElement> TradeReportAsync(string? orderId = null, CancellationToken ct = default)
+    {
+        var headers = AuthHeaders("application/x-www-form-urlencoded");
+        headers["accept"] = "application/json";
+        var (_, data, _) = await _rest.RequestAsync("GET",
+            _config.GetUrl("trade_report"),
+            queryParams: ServerIdQuery(),
+            headers: headers, ct: ct);
+        if (string.IsNullOrEmpty(orderId)) return data;
+        if (!data.TryGetProperty("data", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return JsonDocument.Parse("""{"Error":"There is no trades available with the given order id"}""").RootElement.Clone();
+        foreach (var row in arr.EnumerateArray())
+        {
+            if (row.TryGetProperty("nOrdNo", out var n) && n.GetString() == orderId)
+            {
+                return JsonDocument.Parse(JsonSerializer.Serialize(new
+                {
+                    stat = data.TryGetProperty("stat", out var s) ? s.GetString() : null,
+                    stCode = data.TryGetProperty("stCode", out var c) ? c.GetInt32() : 0,
+                    data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(row.GetRawText()),
+                })).RootElement.Clone();
+            }
+        }
+        return JsonDocument.Parse("""{"Error":"There is no trades available with the given order id"}""").RootElement.Clone();
+    }
+}

--- a/client/dotnet-client/NeoApi/Api/PortfolioApi.cs
+++ b/client/dotnet-client/NeoApi/Api/PortfolioApi.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using Kotak.Neo.Rest;
+using Kotak.Neo.Validation;
+
+namespace Kotak.Neo.Api;
+
+public class PortfolioApi
+{
+    private readonly RestClient _rest;
+    private readonly Configuration _config;
+
+    public PortfolioApi(RestClient rest, Configuration config)
+    {
+        _rest = rest;
+        _config = config;
+    }
+
+    private Dictionary<string, string> Auth(string contentType) => new()
+    {
+        ["Sid"] = _config.EditSid ?? "",
+        ["Auth"] = _config.EditToken ?? "",
+        ["Content-Type"] = contentType,
+    };
+
+    private Dictionary<string, string> ServerId() =>
+        new() { ["sId"] = _config.ServerId ?? "" };
+
+    public async Task<JsonElement> PositionsAsync(CancellationToken ct = default)
+    {
+        var headers = Auth("application/x-www-form-urlencoded");
+        headers["accept"] = "application/json";
+        var (_, data, _) = await _rest.RequestAsync("GET",
+            _config.GetUrl("positions"),
+            queryParams: ServerId(), headers: headers, ct: ct);
+        return data;
+    }
+
+    public async Task<JsonElement> HoldingsAsync(CancellationToken ct = default)
+    {
+        var headers = Auth("application/x-www-form-urlencoded");
+        headers["accept"] = "*/*";
+        var (_, data, _) = await _rest.RequestAsync("GET",
+            _config.GetUrl("holdings"),
+            queryParams: ServerId(), headers: headers, ct: ct);
+        return data;
+    }
+
+    public async Task<JsonElement> LimitsAsync(string segment = "ALL", string exchange = "ALL", string product = "ALL", CancellationToken ct = default)
+    {
+        Validators.ValidateLimits(segment, exchange, product);
+        var (_, data, _) = await _rest.RequestAsync("POST",
+            _config.GetUrl("limits"),
+            queryParams: ServerId(),
+            headers: Auth("application/x-www-form-urlencoded"),
+            body: new Dictionary<string, object?>
+            {
+                ["seg"] = segment, ["exch"] = exchange, ["prod"] = product,
+            },
+            ct: ct);
+        return data;
+    }
+}

--- a/client/dotnet-client/NeoApi/Api/QuotesApi.cs
+++ b/client/dotnet-client/NeoApi/Api/QuotesApi.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using Kotak.Neo.Models;
+using Kotak.Neo.Rest;
+
+namespace Kotak.Neo.Api;
+
+public class QuotesApi
+{
+    private readonly RestClient _rest;
+    private readonly Configuration _config;
+
+    public QuotesApi(RestClient rest, Configuration config)
+    {
+        _rest = rest;
+        _config = config;
+    }
+
+    public async Task<JsonElement> QuotesAsync(IEnumerable<QuoteInstrument> instruments, string? quoteType = null, CancellationToken ct = default)
+    {
+        var list = instruments?.ToList() ?? new List<QuoteInstrument>();
+        if (list.Count == 0)
+            return JsonDocument.Parse("""{"error":[{"message":"Validation Errors! instrument_tokens are missing"}]}""").RootElement.Clone();
+
+        var qt = string.IsNullOrEmpty(quoteType) ? "all" : quoteType!;
+        var joined = string.Join(",", list.Select(i => $"{i.ExchangeSegment}|{i.InstrumentToken}"));
+        var raw = _config.GetUrl("quotes_neo_symbol");
+        var url = raw
+            .Replace("{neo_symbols}", Uri.EscapeDataString(joined))
+            .Replace("{quote_type}", qt);
+
+        var (_, data, _) = await _rest.RequestAsync("GET", url,
+            headers: new Dictionary<string, string>
+            {
+                ["Authorization"] = _config.ConsumerKey ?? "",
+                ["Content-Type"] = "application/x-www-form-urlencoded",
+            }, ct: ct);
+        return data;
+    }
+}

--- a/client/dotnet-client/NeoApi/Api/ScripApi.cs
+++ b/client/dotnet-client/NeoApi/Api/ScripApi.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using Kotak.Neo.Rest;
+
+namespace Kotak.Neo.Api;
+
+public class ScripApi
+{
+    private readonly RestClient _rest;
+    private readonly Configuration _config;
+
+    public ScripApi(RestClient rest, Configuration config)
+    {
+        _rest = rest;
+        _config = config;
+    }
+
+    public async Task<JsonElement> ScripMasterAsync(string? exchangeSegment = null, CancellationToken ct = default)
+    {
+        var (status, data, _) = await _rest.RequestAsync("GET",
+            _config.GetUrl("scrip_master"),
+            headers: new Dictionary<string, string>
+            {
+                ["Authorization"] = _config.ConsumerKey ?? "",
+                ["Content-Type"] = "application/x-www-form-urlencoded",
+            }, ct: ct);
+        if (status != 200) return data;
+
+        if (!data.TryGetProperty("data", out var inner)) return data;
+        if (string.IsNullOrEmpty(exchangeSegment)) return inner;
+
+        if (!Settings.ExchangeSegment.TryGetValue(exchangeSegment, out var seg))
+            return JsonDocument.Parse("""{"Error":"Exchange segment not found"}""").RootElement.Clone();
+
+        if (inner.TryGetProperty("filesPaths", out var paths) && paths.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var p in paths.EnumerateArray())
+            {
+                var s = p.GetString();
+                if (s != null && s.Contains(seg, StringComparison.OrdinalIgnoreCase))
+                    return JsonDocument.Parse(JsonSerializer.Serialize(new { path = s })).RootElement.Clone();
+            }
+        }
+        return JsonDocument.Parse("""{"Error":"Exchange segment not found"}""").RootElement.Clone();
+    }
+
+    public async Task<JsonElement> SearchScripAsync(string exchangeSegment, string symbol = "",
+        string? expiry = null, string? optionType = null, string? strikePrice = null, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(exchangeSegment))
+            return JsonDocument.Parse("""{"error":[{"code":"10300","message":"Validation Errors! Exchange Segment is Mandate to proceed further"}]}""").RootElement.Clone();
+
+        var master = await ScripMasterAsync(exchangeSegment, ct).ConfigureAwait(false);
+        if (!master.TryGetProperty("path", out var path))
+            return JsonDocument.Parse("""{"Error":"Exchange Segment is not available"}""").RootElement.Clone();
+
+        return JsonDocument.Parse(JsonSerializer.Serialize(new
+        {
+            exchange_segment = exchangeSegment,
+            symbol = symbol.ToLowerInvariant(),
+            expiry,
+            option_type = optionType,
+            strike_price = strikePrice,
+            csv_url = path.GetString(),
+            hint = "Download csv_url and filter client-side by symbol/expiry/strike",
+        })).RootElement.Clone();
+    }
+}

--- a/client/dotnet-client/NeoApi/Configuration.cs
+++ b/client/dotnet-client/NeoApi/Configuration.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using Kotak.Neo.Exceptions;
+
+namespace Kotak.Neo;
+
+public class Configuration
+{
+    public string Host { get; set; }
+    public string? BearerToken { get; set; }
+    public string? ViewToken { get; set; }
+    public string? Sid { get; set; }
+    public string? UserId { get; set; }
+    public string? EditToken { get; set; }
+    public string? EditSid { get; set; }
+    public string? EditRid { get; set; }
+    public string? ServerId { get; set; }
+    public string? NeoFinKey { get; set; }
+    public string? DataCenter { get; set; }
+    public string? BaseUrl { get; set; }
+    public string? ConsumerKey { get; set; }
+
+    public Configuration(string environment = "uat")
+    {
+        Host = environment;
+    }
+
+    public bool IsLoggedIn => !string.IsNullOrEmpty(EditToken) && !string.IsNullOrEmpty(EditSid);
+
+    public string GetDomain(bool sessionInit = false)
+    {
+        var host = Host.Trim().ToLowerInvariant();
+        if (host != "prod" && host != "uat")
+            throw new ApiValueError("environment must be 'prod' or 'uat'");
+        if (sessionInit) return Urls.BaseUrl;
+        if (host == "prod") return string.IsNullOrEmpty(BaseUrl) ? Urls.ProdBaseUrl : BaseUrl!;
+        return Urls.UatBaseUrl;
+    }
+
+    public string GetUrl(string apiInfo)
+    {
+        var host = Host.Trim().ToLowerInvariant();
+        var domain = GetDomain(false).TrimEnd('/');
+        var path = host == "prod"
+            ? (Urls.ProdPaths.TryGetValue(apiInfo, out var p) ? p : null)
+            : (Urls.UatPaths.TryGetValue(apiInfo, out var p2) ? p2 : null);
+        if (path == null) throw new ApiValueError($"unknown endpoint: {apiInfo}");
+        return $"{domain}/{path}";
+    }
+
+    public string GetNeoFinKey()
+    {
+        if (!string.IsNullOrEmpty(NeoFinKey)) return NeoFinKey!;
+        return Host.Trim().Equals("prod", StringComparison.OrdinalIgnoreCase)
+            ? "neotradeapi"
+            : "bQJNkL5z8m4aGcRgjDvXhHfSx7VpZnE";
+    }
+
+    public string ExtractUserId(string viewToken)
+    {
+        if (string.IsNullOrEmpty(viewToken))
+            throw new ApiValueError("view_token is empty — call TotpLogin first");
+        var parts = viewToken.Split('.');
+        if (parts.Length < 2) throw new ApiValueError("invalid JWT");
+        var payload = parts[1].Replace('-', '+').Replace('_', '/');
+        payload = payload.PadRight(payload.Length + (4 - payload.Length % 4) % 4, '=');
+        var json = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(payload));
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("sub", out var sub))
+            throw new ApiKeyError("sub claim missing from token");
+        UserId = sub.GetString();
+        return UserId!;
+    }
+}

--- a/client/dotnet-client/NeoApi/Exceptions/ApiException.cs
+++ b/client/dotnet-client/NeoApi/Exceptions/ApiException.cs
@@ -1,0 +1,41 @@
+namespace Kotak.Neo.Exceptions;
+
+public class OpenApiException : Exception
+{
+    public OpenApiException(string message) : base(message) { }
+}
+
+public class ApiTypeError : OpenApiException
+{
+    public ApiTypeError(string msg) : base(msg) { }
+}
+
+public class ApiValueError : OpenApiException
+{
+    public ApiValueError(string msg) : base(msg) { }
+}
+
+public class ApiAttributeError : OpenApiException
+{
+    public ApiAttributeError(string msg) : base(msg) { }
+}
+
+public class ApiKeyError : OpenApiException
+{
+    public ApiKeyError(string msg) : base(msg) { }
+}
+
+public class ApiException : OpenApiException
+{
+    public int Status { get; }
+    public string Reason { get; }
+    public string? Body { get; }
+
+    public ApiException(int status, string reason, string? body = null)
+        : base($"({status}) {reason}{(body is null ? "" : $": {body}")}")
+    {
+        Status = status;
+        Reason = reason;
+        Body = body;
+    }
+}

--- a/client/dotnet-client/NeoApi/Models/Requests.cs
+++ b/client/dotnet-client/NeoApi/Models/Requests.cs
@@ -1,0 +1,75 @@
+namespace Kotak.Neo.Models;
+
+public class PlaceOrderRequest
+{
+    public string ExchangeSegment { get; set; } = "";
+    public string Product { get; set; } = "";
+    public string Price { get; set; } = "";
+    public string OrderType { get; set; } = "";
+    public string Quantity { get; set; } = "";
+    public string Validity { get; set; } = "";
+    public string TradingSymbol { get; set; } = "";
+    public string TransactionType { get; set; } = "";
+    public string? AMO { get; set; }
+    public string? DisclosedQuantity { get; set; }
+    public string? MarketProtection { get; set; }
+    public string? PF { get; set; }
+    public string? TriggerPrice { get; set; }
+    public string? Tag { get; set; }
+    public string? ScripToken { get; set; }
+    public string? SquareOffType { get; set; }
+    public string? StopLossType { get; set; }
+    public string? StopLossValue { get; set; }
+    public string? SquareOffValue { get; set; }
+    public string? LastTradedPrice { get; set; }
+    public string? TrailingStopLoss { get; set; }
+    public string? TrailingSLValue { get; set; }
+}
+
+public class ModifyOrderRequest
+{
+    public string OrderId { get; set; } = "";
+    public string Price { get; set; } = "";
+    public string OrderType { get; set; } = "";
+    public string Quantity { get; set; } = "";
+    public string Validity { get; set; } = "";
+    public string? InstrumentToken { get; set; }
+    public string? ExchangeSegment { get; set; }
+    public string? Product { get; set; }
+    public string? TradingSymbol { get; set; }
+    public string? TransactionType { get; set; }
+    public string? TriggerPrice { get; set; }
+    public string? DD { get; set; }
+    public string? MarketProtection { get; set; }
+    public string? DisclosedQuantity { get; set; }
+    public string? FilledQuantity { get; set; }
+    public string? AMO { get; set; }
+}
+
+public class MarginRequiredRequest
+{
+    public string ExchangeSegment { get; set; } = "";
+    public string Price { get; set; } = "";
+    public string OrderType { get; set; } = "";
+    public string Product { get; set; } = "";
+    public string Quantity { get; set; } = "";
+    public string InstrumentToken { get; set; } = "";
+    public string TransactionType { get; set; } = "";
+    public string? TriggerPrice { get; set; }
+    public string? BrokerName { get; set; }
+    public string? BranchId { get; set; }
+    public string? StopLossType { get; set; }
+    public string? StopLossValue { get; set; }
+    public string? SquareOffType { get; set; }
+    public string? SquareOffValue { get; set; }
+    public string? TrailingStopLoss { get; set; }
+    public string? TrailingSLValue { get; set; }
+}
+
+public class Instrument
+{
+    public string InstrumentToken { get; set; } = "";
+    public string ExchangeSegment { get; set; } = "";
+}
+
+public class QuoteInstrument : Instrument { }

--- a/client/dotnet-client/NeoApi/NeoApi.cs
+++ b/client/dotnet-client/NeoApi/NeoApi.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using Kotak.Neo.Api;
+using Kotak.Neo.Models;
+using Kotak.Neo.Rest;
+using Kotak.Neo.WebSocket;
+
+namespace Kotak.Neo;
+
+/// <summary>
+/// NeoApi — top-level SDK entry point. Mirrors the Python NeoAPI class.
+/// </summary>
+public class NeoApi : IDisposable
+{
+    public Configuration Configuration { get; }
+    private readonly RestClient _rest;
+    private readonly LoginApi _login;
+    private readonly OrderApi _orders;
+    private readonly PortfolioApi _portfolio;
+    private readonly MarginApi _margin;
+    private readonly ScripApi _scrip;
+    private readonly QuotesApi _quotes;
+    private NeoWebSocket? _ws;
+
+    public event Action<string>? OnOpen;
+    public event Action<object>? OnMessage;
+    public event Action<Exception>? OnError;
+    public event Action<string>? OnClose;
+
+    public NeoApi(string environment = "uat", string? accessToken = null, string? neoFinKey = null, string? consumerKey = null)
+    {
+        Configuration = new Configuration(environment)
+        {
+            BearerToken = accessToken,
+            NeoFinKey = neoFinKey,
+            ConsumerKey = consumerKey,
+        };
+        _rest = new RestClient(Configuration);
+        _login = new LoginApi(_rest, Configuration);
+        _orders = new OrderApi(_rest, Configuration);
+        _portfolio = new PortfolioApi(_rest, Configuration);
+        _margin = new MarginApi(_rest, Configuration);
+        _scrip = new ScripApi(_rest, Configuration);
+        _quotes = new QuotesApi(_rest, Configuration);
+    }
+
+    private JsonElement? RequireLogin()
+    {
+        if (!Configuration.IsLoggedIn)
+            return JsonDocument.Parse("""{"Error Message":"Complete the 2fa process before accessing this application"}""").RootElement.Clone();
+        return null;
+    }
+
+    // ---------- Auth ----------
+    public Task<JsonElement> TotpLoginAsync(string mobileNumber, string ucc, string totp, CancellationToken ct = default)
+        => _login.TotpLoginAsync(mobileNumber, ucc, totp, ct);
+
+    public Task<JsonElement> TotpValidateAsync(string mpin, CancellationToken ct = default)
+        => _login.TotpValidateAsync(mpin, ct);
+
+    public JsonElement Logout()
+    {
+        var gate = RequireLogin(); if (gate is not null) return gate.Value;
+        Configuration.BearerToken = null;
+        Configuration.EditSid = null;
+        Configuration.EditToken = null;
+        return JsonDocument.Parse("""{"State":"OK","message":"You have been successfully logged out"}""").RootElement.Clone();
+    }
+
+    // ---------- Orders ----------
+    public Task<JsonElement> PlaceOrderAsync(PlaceOrderRequest req, CancellationToken ct = default)
+        => Gated(() => _orders.PlaceOrderAsync(req, ct));
+
+    public Task<JsonElement> ModifyOrderAsync(ModifyOrderRequest req, CancellationToken ct = default)
+        => Gated(() => _orders.ModifyOrderAsync(req, ct));
+
+    public Task<JsonElement> CancelOrderAsync(string orderId, string amo = "NO", bool verify = false, CancellationToken ct = default)
+        => Gated(() => _orders.CancelOrderAsync(orderId, amo, verify, ct));
+
+    public Task<JsonElement> CancelCoverOrderAsync(string orderId, string amo = "NO", bool verify = false, CancellationToken ct = default)
+        => Gated(() => _orders.CancelCoverOrderAsync(orderId, amo, verify, ct));
+
+    public Task<JsonElement> CancelBracketOrderAsync(string orderId, string amo = "NO", bool verify = false, CancellationToken ct = default)
+        => Gated(() => _orders.CancelBracketOrderAsync(orderId, amo, verify, ct));
+
+    // ---------- Reports ----------
+    public Task<JsonElement> OrderReportAsync(CancellationToken ct = default) => Gated(() => _orders.OrderReportAsync(ct));
+    public Task<JsonElement> OrderHistoryAsync(string orderId, CancellationToken ct = default) => Gated(() => _orders.OrderHistoryAsync(orderId, ct));
+    public Task<JsonElement> TradeReportAsync(string? orderId = null, CancellationToken ct = default) => Gated(() => _orders.TradeReportAsync(orderId, ct));
+
+    // ---------- Portfolio ----------
+    public Task<JsonElement> PositionsAsync(CancellationToken ct = default) => Gated(() => _portfolio.PositionsAsync(ct));
+    public Task<JsonElement> HoldingsAsync(CancellationToken ct = default) => Gated(() => _portfolio.HoldingsAsync(ct));
+    public Task<JsonElement> LimitsAsync(string segment = "ALL", string exchange = "ALL", string product = "ALL", CancellationToken ct = default)
+        => Gated(() => _portfolio.LimitsAsync(segment, exchange, product, ct));
+
+    // ---------- Pricing ----------
+    public Task<JsonElement> MarginRequiredAsync(MarginRequiredRequest req, CancellationToken ct = default)
+        => Gated(() => _margin.MarginRequiredAsync(req, ct));
+    public Task<JsonElement> QuotesAsync(IEnumerable<QuoteInstrument> instruments, string? quoteType = null, CancellationToken ct = default)
+        => _quotes.QuotesAsync(instruments, quoteType, ct);
+
+    // ---------- Scrip ----------
+    public Task<JsonElement> ScripMasterAsync(string? exchangeSegment = null, CancellationToken ct = default)
+        => Gated(() => _scrip.ScripMasterAsync(exchangeSegment, ct));
+    public Task<JsonElement> SearchScripAsync(string exchangeSegment, string symbol = "", string? expiry = null,
+        string? optionType = null, string? strikePrice = null, CancellationToken ct = default)
+        => Gated(() => _scrip.SearchScripAsync(exchangeSegment, symbol, expiry, optionType, strikePrice, ct));
+
+    // ---------- Streaming ----------
+    public async Task SubscribeAsync(IEnumerable<Instrument> instruments, bool isIndex = false, bool isDepth = false, CancellationToken ct = default)
+    {
+        if (!Configuration.IsLoggedIn) { OnError?.Invoke(new InvalidOperationException("not logged in")); return; }
+        EnsureSocket();
+        await _ws!.GetLiveFeedAsync(instruments, isIndex, isDepth, ct).ConfigureAwait(false);
+    }
+    public async Task UnSubscribeAsync(IEnumerable<Instrument> instruments, bool isIndex = false, bool isDepth = false, CancellationToken ct = default)
+    {
+        if (!Configuration.IsLoggedIn) { OnError?.Invoke(new InvalidOperationException("not logged in")); return; }
+        EnsureSocket();
+        await _ws!.UnSubscribeListAsync(instruments, isIndex, isDepth, ct).ConfigureAwait(false);
+    }
+    public async Task SubscribeToOrderFeedAsync(CancellationToken ct = default)
+    {
+        if (!Configuration.IsLoggedIn) { OnError?.Invoke(new InvalidOperationException("not logged in")); return; }
+        EnsureSocket();
+        await _ws!.GetOrderFeedAsync(ct).ConfigureAwait(false);
+    }
+
+    private void EnsureSocket()
+    {
+        if (_ws is not null) return;
+        _ws = new NeoWebSocket(
+            Configuration.EditSid ?? "",
+            Configuration.EditToken ?? "",
+            Configuration.ServerId ?? "",
+            Configuration.DataCenter);
+        _ws.OnOpen += m => OnOpen?.Invoke(m);
+        _ws.OnMessage += m => OnMessage?.Invoke(m);
+        _ws.OnError += e => OnError?.Invoke(e);
+        _ws.OnClose += m => OnClose?.Invoke(m);
+    }
+
+    private async Task<JsonElement> Gated(Func<Task<JsonElement>> op)
+    {
+        var gate = RequireLogin();
+        if (gate is not null) return gate.Value;
+        try { return await op().ConfigureAwait(false); }
+        catch (Exception ex)
+        {
+            return JsonDocument.Parse(JsonSerializer.Serialize(new { Error = ex.Message })).RootElement.Clone();
+        }
+    }
+
+    public void Dispose() => _ws?.Dispose();
+}

--- a/client/dotnet-client/NeoApi/NeoApi.csproj
+++ b/client/dotnet-client/NeoApi/NeoApi.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>Kotak.Neo</RootNamespace>
+    <AssemblyName>Kotak.Neo</AssemblyName>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/client/dotnet-client/NeoApi/Rest/RestClient.cs
+++ b/client/dotnet-client/NeoApi/Rest/RestClient.cs
@@ -25,6 +25,7 @@ public class RestClient
         object? body = null,
         CancellationToken ct = default)
     {
+        var m = method.ToUpperInvariant();
         headers ??= new Dictionary<string, string>();
         if (!headers.ContainsKey("Content-Type"))
             headers["Content-Type"] = "application/json";
@@ -36,10 +37,10 @@ public class RestClient
             url += (url.Contains('?') ? "&" : "?") + pairs;
         }
 
-        var request = new HttpRequestMessage(new HttpMethod(method.ToUpperInvariant()), url);
+        var request = new HttpRequestMessage(new HttpMethod(m), url);
         var contentType = headers["Content-Type"];
 
-        if (method is "POST" or "PUT" or "PATCH" or "DELETE")
+        if (m is "POST" or "PUT" or "PATCH" or "DELETE")
         {
             if (contentType.Contains("json", StringComparison.OrdinalIgnoreCase))
             {

--- a/client/dotnet-client/NeoApi/Rest/RestClient.cs
+++ b/client/dotnet-client/NeoApi/Rest/RestClient.cs
@@ -1,0 +1,87 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Kotak.Neo.Exceptions;
+
+namespace Kotak.Neo.Rest;
+
+public class RestClient
+{
+    private readonly HttpClient _http;
+    public Configuration Config { get; }
+
+    public RestClient(Configuration config, HttpClient? http = null)
+    {
+        Config = config;
+        _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd("NeoTradeApi-dotnet/1.0.0");
+    }
+
+    public async Task<(int Status, JsonElement Data, string Text)> RequestAsync(
+        string method,
+        string url,
+        IDictionary<string, string>? queryParams = null,
+        IDictionary<string, string>? headers = null,
+        object? body = null,
+        CancellationToken ct = default)
+    {
+        headers ??= new Dictionary<string, string>();
+        if (!headers.ContainsKey("Content-Type"))
+            headers["Content-Type"] = "application/json";
+
+        if (queryParams is { Count: > 0 })
+        {
+            var pairs = string.Join("&", queryParams.Select(kv =>
+                $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
+            url += (url.Contains('?') ? "&" : "?") + pairs;
+        }
+
+        var request = new HttpRequestMessage(new HttpMethod(method.ToUpperInvariant()), url);
+        var contentType = headers["Content-Type"];
+
+        if (method is "POST" or "PUT" or "PATCH" or "DELETE")
+        {
+            if (contentType.Contains("json", StringComparison.OrdinalIgnoreCase))
+            {
+                var json = body is null ? "" : JsonSerializer.Serialize(body);
+                request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            }
+            else if (contentType.Contains("x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
+            {
+                var pairs = new List<KeyValuePair<string, string>>();
+                if (body is not null)
+                {
+                    var json = JsonSerializer.Serialize(body);
+                    pairs.Add(new KeyValuePair<string, string>("jData", json));
+                }
+                request.Content = new FormUrlEncodedContent(pairs);
+            }
+            else
+            {
+                throw new ApiException(0, "Invalid Content-Type", contentType);
+            }
+        }
+
+        foreach (var (k, v) in headers)
+        {
+            if (k.Equals("Content-Type", StringComparison.OrdinalIgnoreCase)) continue;
+            request.Headers.TryAddWithoutValidation(k, v);
+        }
+
+        var resp = await _http.SendAsync(request, ct).ConfigureAwait(false);
+        var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        JsonElement data;
+        try
+        {
+            data = string.IsNullOrEmpty(text)
+                ? JsonDocument.Parse("{}").RootElement.Clone()
+                : JsonDocument.Parse(text).RootElement.Clone();
+        }
+        catch
+        {
+            using var doc = JsonDocument.Parse(JsonSerializer.Serialize(new { raw = text }));
+            data = doc.RootElement.Clone();
+        }
+        return ((int)resp.StatusCode, data, text);
+    }
+}

--- a/client/dotnet-client/NeoApi/Settings.cs
+++ b/client/dotnet-client/NeoApi/Settings.cs
@@ -1,0 +1,58 @@
+namespace Kotak.Neo;
+
+public static class Settings
+{
+    public static readonly Dictionary<string, string> ExchangeSegment = new()
+    {
+        ["nse_cm"] = "nse_cm", ["NSE"] = "nse_cm", ["nse"] = "nse_cm",
+        ["BSE"] = "bse_cm", ["bse"] = "bse_cm", ["bse_cm"] = "bse_cm",
+        ["NFO"] = "nse_fo", ["nse_fo"] = "nse_fo", ["nfo"] = "nse_fo",
+        ["BFO"] = "bse_fo", ["bse_fo"] = "bse_fo", ["bfo"] = "bse_fo",
+        ["CDS"] = "cde_fo", ["cde_fo"] = "cde_fo", ["cds"] = "cde_fo",
+        ["BCD"] = "bcs-fo", ["bcs-fo"] = "bcs-fo", ["bcd"] = "bcs-fo",
+        ["MCX"] = "mcx_fo", ["mcx"] = "mcx_fo", ["mcx_fo"] = "mcx_fo",
+    };
+
+    public static readonly Dictionary<string, string> Product = new()
+    {
+        ["Normal"] = "NRML", ["NRML"] = "NRML",
+        ["CNC"] = "CNC", ["cnc"] = "CNC", ["Cash and Carry"] = "CNC",
+        ["MIS"] = "MIS", ["mis"] = "MIS",
+        ["INTRADAY"] = "INTRADAY", ["intraday"] = "INTRADAY",
+        ["Cover Order"] = "CO", ["co"] = "CO", ["CO"] = "CO",
+        ["BO"] = "BO", ["Bracket Order"] = "BO", ["bo"] = "BO",
+        ["mtf"] = "MTF", ["MTF"] = "MTF",
+    };
+
+    public static readonly Dictionary<string, string> OrderType = new()
+    {
+        ["Limit"] = "L", ["L"] = "L", ["l"] = "L",
+        ["MKT"] = "MKT", ["mkt"] = "MKT", ["Market"] = "MKT",
+        ["sl"] = "SL", ["SL"] = "SL", ["Stop loss limit"] = "SL",
+        ["Stop loss market"] = "SL-M", ["SL-M"] = "SL-M", ["sl-m"] = "SL-M",
+        ["Spread"] = "SP", ["SP"] = "SP", ["sp"] = "SP",
+        ["2L"] = "2L", ["2l"] = "2L", ["Two Leg"] = "2L",
+        ["3L"] = "3L", ["3l"] = "3L", ["Three leg"] = "3L",
+    };
+
+    public static readonly HashSet<string> SegmentLimits = new() { "CASH", "CUR", "FO", "ALL" };
+    public static readonly HashSet<string> ExchangeLimits = new() { "NSE", "BSE", "ALL" };
+    public static readonly HashSet<string> ProductLimits = new() { "CNC", "MIS", "NRML", "ALL" };
+
+    public static readonly Dictionary<string, string> ReqTypeValues = new()
+    {
+        ["CONNECTION"] = "cn",
+        ["SCRIP_SUBS"] = "mws",
+        ["SCRIP_UNSUBS"] = "mwu",
+        ["INDEX_SUBS"] = "ifs",
+        ["INDEX_UNSUBS"] = "ifu",
+        ["DEPTH_SUBS"] = "dps",
+        ["DEPTH_UNSUBS"] = "dpu",
+        ["SNAP_MW"] = "mwsp",
+        ["SNAP_DP"] = "dpsp",
+        ["SNAP_IF"] = "ifsp",
+    };
+
+    public const string OrderSource = "NEOTRADEAPI";
+    public const int QuotesChannel = 1;
+}

--- a/client/dotnet-client/NeoApi/Urls.cs
+++ b/client/dotnet-client/NeoApi/Urls.cs
@@ -1,0 +1,57 @@
+namespace Kotak.Neo;
+
+public static class Urls
+{
+    public const string WebSocketUrl = "wss://mlhsm.kotaksecurities.com";
+    public const string OrderFeedUrl = "wss://mis.kotaksecurities.com/realtime";
+    public const string OrderFeedUrlAdc = "wss://cis.kotaksecurities.com/realtime";
+    public const string OrderFeedUrlE21 = "wss://e21.kotaksecurities.com/realtime";
+    public const string OrderFeedUrlE22 = "wss://e22.kotaksecurities.com/realtime";
+    public const string OrderFeedUrlE41 = "wss://e41.kotaksecurities.com/realtime";
+    public const string OrderFeedUrlE43 = "wss://e43.kotaksecurities.com/realtime";
+
+    public const string BaseUrl = "https://mis.kotaksecurities.com";
+
+    public const string UatBaseUrl = "https://nsbxapi-gw.kotaksecurities.com/";
+    public const string ProdBaseUrl = "https://mnapi.kotaksecurities.com/";
+
+    public static readonly Dictionary<string, string> UatPaths = new()
+    {
+        ["totp_login"] = "api/1.0/login/v6/totp/login",
+        ["totp_validate"] = "api/1.0/login/v6/totp/validate",
+        ["place_order"] = "orderapi/1.0/quick/order/rule/ms/place",
+        ["cancel_order"] = "orderapi/1.0/quick/order/cancel",
+        ["modify_order"] = "orderapi/1.0/quick/order/vr/modify",
+        ["order_history"] = "orderapi/1.0/quick/order/history",
+        ["order_book"] = "orderapi/1.0/quick/user/orders",
+        ["trade_report"] = "orderapi/1.0/quick/user/trades",
+        ["positions"] = "orderapi/1.0/quick/user/positions",
+        ["holdings"] = "portfolio/1.0/portfolio/v1/holdings",
+        ["margin"] = "orderapi/1.0/quick/user/check-margin",
+        ["scrip_master"] = "scrip/1.0/masterscrip/file-paths",
+        ["limits"] = "orderapi/1.0/quick/user/limits",
+        ["logout"] = "api/1.0/logout",
+        ["quotes_neo_symbol"] = "script-details/1.0/quotes/neosymbol/{neo_symbols}/{quote_type}",
+    };
+
+    public static readonly Dictionary<string, string> ProdPaths = new()
+    {
+        ["totp_login"] = "login/1.0/tradeApiLogin",
+        ["totp_validate"] = "login/1.0/tradeApiValidate",
+        ["place_order"] = "quick/order/rule/ms/place",
+        ["cancel_order"] = "quick/order/cancel",
+        ["cancel_cover_order"] = "quick/order/co/exit",
+        ["cancel_bracket_order"] = "quick/order/bo/exit",
+        ["modify_order"] = "quick/order/vr/modify",
+        ["order_history"] = "quick/order/history",
+        ["order_book"] = "quick/user/orders",
+        ["trade_report"] = "quick/user/trades",
+        ["positions"] = "quick/user/positions",
+        ["holdings"] = "portfolio/v1/holdings",
+        ["margin"] = "quick/user/check-margin",
+        ["scrip_master"] = "script-details/1.0/masterscrip/file-paths",
+        ["limits"] = "quick/user/limits",
+        ["logout"] = "apim/login/2.0/logout",
+        ["quotes_neo_symbol"] = "/script-details/1.0/quotes/neosymbol/{neo_symbols}/{quote_type}",
+    };
+}

--- a/client/dotnet-client/NeoApi/Validation/Validators.cs
+++ b/client/dotnet-client/NeoApi/Validation/Validators.cs
@@ -1,0 +1,61 @@
+using Kotak.Neo.Exceptions;
+
+namespace Kotak.Neo.Validation;
+
+public static class Validators
+{
+    private static void NonEmpty(string? value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ApiValueError($"{name} is mandatory");
+    }
+
+    public static void ValidatePlaceOrder(string exchangeSegment, string product, string price,
+        string orderType, string quantity, string validity, string tradingSymbol, string transactionType)
+    {
+        NonEmpty(exchangeSegment, "exchange_segment");
+        NonEmpty(product, "product");
+        NonEmpty(price, "price");
+        NonEmpty(orderType, "order_type");
+        NonEmpty(quantity, "quantity");
+        NonEmpty(validity, "validity");
+        NonEmpty(tradingSymbol, "trading_symbol");
+        NonEmpty(transactionType, "transaction_type");
+        if (!Settings.ExchangeSegment.ContainsKey(exchangeSegment))
+            throw new ApiValueError($"invalid exchange_segment: {exchangeSegment}");
+        if (!Settings.Product.ContainsKey(product))
+            throw new ApiValueError($"invalid product: {product}");
+        if (!Settings.OrderType.ContainsKey(orderType))
+            throw new ApiValueError($"invalid order_type: {orderType}");
+        var tt = transactionType.ToUpperInvariant();
+        if (tt != "B" && tt != "S" && tt != "BUY" && tt != "SELL")
+            throw new ApiValueError("transaction_type must be B/S");
+    }
+
+    public static void ValidateCancelOrder(string orderId) => NonEmpty(orderId, "order_id");
+    public static void ValidateOrderHistory(string orderId) => NonEmpty(orderId, "order_id");
+
+    public static void ValidateMargin(string exchangeSegment, string price, string orderType,
+        string product, string quantity, string instrumentToken, string transactionType)
+    {
+        NonEmpty(exchangeSegment, "exchange_segment");
+        NonEmpty(price, "price");
+        NonEmpty(orderType, "order_type");
+        NonEmpty(product, "product");
+        NonEmpty(quantity, "quantity");
+        NonEmpty(instrumentToken, "instrument_token");
+        NonEmpty(transactionType, "transaction_type");
+        if (!Settings.ExchangeSegment.ContainsKey(exchangeSegment))
+            throw new ApiValueError($"invalid exchange_segment: {exchangeSegment}");
+    }
+
+    public static void ValidateLimits(string segment, string exchange, string product)
+    {
+        if (!Settings.SegmentLimits.Contains(segment))
+            throw new ApiValueError($"invalid segment: {segment}");
+        if (!Settings.ExchangeLimits.Contains(exchange))
+            throw new ApiValueError($"invalid exchange: {exchange}");
+        if (!Settings.ProductLimits.Contains(product))
+            throw new ApiValueError($"invalid product: {product}");
+    }
+}

--- a/client/dotnet-client/NeoApi/Validation/Validators.cs
+++ b/client/dotnet-client/NeoApi/Validation/Validators.cs
@@ -4,6 +4,10 @@ namespace Kotak.Neo.Validation;
 
 public static class Validators
 {
+    private static readonly HashSet<string> ValidityValues = new() { "DAY", "IOC" };
+    private static readonly HashSet<string> PlaceOrderTt = new() { "B", "S", "Buy", "Sell" };
+    private static readonly HashSet<string> MarginTt = new() { "B", "S", "Buy", "Sell", "sell", "buy" };
+
     private static void NonEmpty(string? value, string name)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -27,9 +31,10 @@ public static class Validators
             throw new ApiValueError($"invalid product: {product}");
         if (!Settings.OrderType.ContainsKey(orderType))
             throw new ApiValueError($"invalid order_type: {orderType}");
-        var tt = transactionType.ToUpperInvariant();
-        if (tt != "B" && tt != "S" && tt != "BUY" && tt != "SELL")
-            throw new ApiValueError("transaction_type must be B/S");
+        if (!ValidityValues.Contains(validity))
+            throw new ApiValueError("Invalid validity. Allowed values are DAY, IOC.");
+        if (!PlaceOrderTt.Contains(transactionType))
+            throw new ApiValueError("Invalid transaction type. Allowed values are B or Buy, S or Sell.");
     }
 
     public static void ValidateCancelOrder(string orderId) => NonEmpty(orderId, "order_id");
@@ -47,6 +52,12 @@ public static class Validators
         NonEmpty(transactionType, "transaction_type");
         if (!Settings.ExchangeSegment.ContainsKey(exchangeSegment))
             throw new ApiValueError($"invalid exchange_segment: {exchangeSegment}");
+        if (!Settings.Product.ContainsKey(product))
+            throw new ApiValueError($"invalid product: {product}");
+        if (!Settings.OrderType.ContainsKey(orderType))
+            throw new ApiValueError($"invalid order_type: {orderType}");
+        if (!MarginTt.Contains(transactionType))
+            throw new ApiValueError("Invalid transaction type. Allowed values are B or Buy, S or Sell.");
     }
 
     public static void ValidateLimits(string segment, string exchange, string product)

--- a/client/dotnet-client/NeoApi/WebSocket/HsWebSocketCodec.cs
+++ b/client/dotnet-client/NeoApi/WebSocket/HsWebSocketCodec.cs
@@ -1,0 +1,33 @@
+using System.Buffers.Binary;
+
+namespace Kotak.Neo.WebSocket;
+
+public record DecodedFrame(int PacketType, byte[] Payload);
+
+public static class HsWebSocketCodec
+{
+    /// <summary>
+    /// Parses a binary market-data frame (packet-count prefixed, length-delimited).
+    /// </summary>
+    public static List<DecodedFrame> Decode(byte[] buf)
+    {
+        var result = new List<DecodedFrame>();
+        if (buf.Length < 1) return result;
+        int count = buf[0];
+        int pos = 1;
+        for (int i = 0; i < count; i++)
+        {
+            if (pos + 2 > buf.Length) break;
+            int len = BinaryPrimitives.ReadUInt16BigEndian(buf.AsSpan(pos, 2));
+            pos += 2;
+            if (pos + len > buf.Length) break;
+            if (len < 1) { pos += len; continue; }
+            int type = buf[pos];
+            var payload = new byte[len - 1];
+            Buffer.BlockCopy(buf, pos + 1, payload, 0, len - 1);
+            pos += len;
+            result.Add(new DecodedFrame(type, payload));
+        }
+        return result;
+    }
+}

--- a/client/dotnet-client/NeoApi/WebSocket/NeoWebSocket.cs
+++ b/client/dotnet-client/NeoApi/WebSocket/NeoWebSocket.cs
@@ -1,0 +1,167 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Kotak.Neo.Models;
+
+namespace Kotak.Neo.WebSocket;
+
+/// <summary>
+/// NeoWebSocket manages the market-data and order-feed WebSocket connections.
+/// Mirrors the Python NeoWebSocket class.
+/// </summary>
+public class NeoWebSocket : IDisposable
+{
+    private readonly string _sid;
+    private readonly string _token;
+    private readonly string _serverId;
+    private readonly string? _dataCenter;
+
+    private ClientWebSocket? _marketSocket;
+    private ClientWebSocket? _orderSocket;
+    private CancellationTokenSource? _marketCts;
+    private CancellationTokenSource? _orderCts;
+
+    public event Action<string>? OnOpen;
+    public event Action<object>? OnMessage;
+    public event Action<Exception>? OnError;
+    public event Action<string>? OnClose;
+
+    public NeoWebSocket(string sid, string token, string serverId, string? dataCenter)
+    {
+        _sid = sid;
+        _token = token;
+        _serverId = serverId;
+        _dataCenter = dataCenter;
+    }
+
+    public async Task GetLiveFeedAsync(IEnumerable<Instrument> instruments, bool isIndex = false, bool isDepth = false, CancellationToken ct = default)
+    {
+        var list = instruments.ToList();
+        var subType = Settings.ReqTypeValues["SCRIP_SUBS"];
+        if (isIndex) subType = Settings.ReqTypeValues["INDEX_SUBS"];
+        if (isDepth) subType = Settings.ReqTypeValues["DEPTH_SUBS"];
+
+        if (_marketSocket == null || _marketSocket.State != WebSocketState.Open)
+            await OpenMarketAsync(ct).ConfigureAwait(false);
+
+        var scrips = string.Join("&", list.Select(i => $"{i.ExchangeSegment}|{i.InstrumentToken}"));
+        await SendAsync(_marketSocket!, new { type = subType, scrips, channelnum = 2 }, ct).ConfigureAwait(false);
+    }
+
+    public async Task UnSubscribeListAsync(IEnumerable<Instrument> instruments, bool isIndex = false, bool isDepth = false, CancellationToken ct = default)
+    {
+        var list = instruments.ToList();
+        var unsub = Settings.ReqTypeValues["SCRIP_UNSUBS"];
+        if (isIndex) unsub = Settings.ReqTypeValues["INDEX_UNSUBS"];
+        if (isDepth) unsub = Settings.ReqTypeValues["DEPTH_UNSUBS"];
+
+        if (_marketSocket is null || _marketSocket.State != WebSocketState.Open)
+            throw new InvalidOperationException("Socket Connection has been closed");
+
+        var scrips = string.Join("&", list.Select(i => $"{i.ExchangeSegment}|{i.InstrumentToken}"));
+        await SendAsync(_marketSocket, new { type = unsub, scrips, channelnum = 2 }, ct).ConfigureAwait(false);
+    }
+
+    public Task GetOrderFeedAsync(CancellationToken ct = default) => OpenOrderAsync(ct);
+
+    private async Task OpenMarketAsync(CancellationToken ct)
+    {
+        _marketSocket = new ClientWebSocket();
+        _marketCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        await _marketSocket.ConnectAsync(new Uri(Urls.WebSocketUrl), _marketCts.Token).ConfigureAwait(false);
+        await SendAsync(_marketSocket, new { type = "cn", Authorization = _token, Sid = _sid }, _marketCts.Token).ConfigureAwait(false);
+        OnOpen?.Invoke("market socket opened");
+        _ = Task.Run(() => ReceiveLoopAsync(_marketSocket, "stock_feed", _marketCts.Token));
+        _ = Task.Run(() => HeartbeatAsync(_marketSocket, "hb", 29, _marketCts.Token));
+    }
+
+    private async Task OpenOrderAsync(CancellationToken ct)
+    {
+        var url = Urls.OrderFeedUrl;
+        switch ((_dataCenter ?? "").ToLowerInvariant())
+        {
+            case "adc": url = Urls.OrderFeedUrlAdc; break;
+            case "e21": url = Urls.OrderFeedUrlE21; break;
+            case "e22": url = Urls.OrderFeedUrlE22; break;
+            case "e41": url = Urls.OrderFeedUrlE41; break;
+            case "e43": url = Urls.OrderFeedUrlE43; break;
+        }
+        _orderSocket = new ClientWebSocket();
+        _orderCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        await _orderSocket.ConnectAsync(new Uri(url), _orderCts.Token).ConfigureAwait(false);
+        await SendAsync(_orderSocket, new { type = "CONNECTION", Authorization = _token, Sid = _sid, source = "WEB" }, _orderCts.Token).ConfigureAwait(false);
+        OnOpen?.Invoke("order feed opened");
+        _ = Task.Run(() => ReceiveLoopAsync(_orderSocket, "order_feed", _orderCts.Token));
+        _ = Task.Run(() => HeartbeatAsync(_orderSocket, "HB", 30, _orderCts.Token));
+    }
+
+    private static async Task SendAsync(ClientWebSocket ws, object payload, CancellationToken ct)
+    {
+        var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload));
+        await ws.SendAsync(bytes, WebSocketMessageType.Text, true, ct).ConfigureAwait(false);
+    }
+
+    private async Task ReceiveLoopAsync(ClientWebSocket ws, string label, CancellationToken ct)
+    {
+        var buffer = new byte[8192];
+        try
+        {
+            while (ws.State == WebSocketState.Open && !ct.IsCancellationRequested)
+            {
+                var ms = new MemoryStream();
+                WebSocketReceiveResult? res;
+                do
+                {
+                    res = await ws.ReceiveAsync(buffer, ct).ConfigureAwait(false);
+                    if (res.MessageType == WebSocketMessageType.Close)
+                    {
+                        OnClose?.Invoke($"{label} closed");
+                        return;
+                    }
+                    ms.Write(buffer, 0, res.Count);
+                } while (!res.EndOfMessage);
+                var payload = ms.ToArray();
+                if (res.MessageType == WebSocketMessageType.Text)
+                {
+                    var text = Encoding.UTF8.GetString(payload);
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(text);
+                        OnMessage?.Invoke(new { type = label, data = doc.RootElement.Clone() });
+                    }
+                    catch
+                    {
+                        OnMessage?.Invoke(new { type = label, data = text });
+                    }
+                }
+                else
+                {
+                    var frames = HsWebSocketCodec.Decode(payload);
+                    OnMessage?.Invoke(new { type = label, data = frames });
+                }
+            }
+        }
+        catch (Exception ex) { OnError?.Invoke(ex); }
+    }
+
+    private async Task HeartbeatAsync(ClientWebSocket ws, string type, int seconds, CancellationToken ct)
+    {
+        try
+        {
+            while (ws.State == WebSocketState.Open && !ct.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(seconds), ct).ConfigureAwait(false);
+                await SendAsync(ws, new { type }, ct).ConfigureAwait(false);
+            }
+        }
+        catch { /* exit quietly on cancel */ }
+    }
+
+    public void Dispose()
+    {
+        _marketCts?.Cancel();
+        _orderCts?.Cancel();
+        _marketSocket?.Dispose();
+        _orderSocket?.Dispose();
+    }
+}

--- a/client/dotnet-client/README.md
+++ b/client/dotnet-client/README.md
@@ -1,0 +1,69 @@
+# Kotak Neo — .NET client
+
+.NET 8 port of the Python `neo_api_client`.
+
+## Install
+
+```bash
+cd client/dotnet-client
+dotnet build
+```
+
+## Quickstart
+
+```csharp
+using Kotak.Neo;
+using Kotak.Neo.Models;
+
+using var client = new NeoApi(environment: "prod", consumerKey: "YOUR_CONSUMER_KEY");
+
+await client.TotpLoginAsync("+919999999999", "ABC12", "123456");
+await client.TotpValidateAsync("1234");
+
+var resp = await client.PlaceOrderAsync(new PlaceOrderRequest
+{
+    ExchangeSegment = "nse_cm",
+    Product = "MIS",
+    Price = "100.50",
+    OrderType = "L",
+    Quantity = "1",
+    Validity = "DAY",
+    TradingSymbol = "RELIANCE-EQ",
+    TransactionType = "B",
+});
+Console.WriteLine(resp);
+```
+
+## Streaming
+
+```csharp
+client.OnMessage += m => Console.WriteLine(m);
+await client.SubscribeAsync(new[]
+{
+    new Instrument { InstrumentToken = "11536", ExchangeSegment = "nse_cm" },
+});
+```
+
+## Method map (Python → .NET)
+
+| Python | .NET |
+|---|---|
+| `totp_login` / `totp_validate` / `logout` | `TotpLoginAsync` / `TotpValidateAsync` / `Logout` |
+| `place_order` / `modify_order` | `PlaceOrderAsync` / `ModifyOrderAsync` |
+| `cancel_order` etc. | `CancelOrderAsync` / `CancelCoverOrderAsync` / `CancelBracketOrderAsync` |
+| `order_report` / `order_history` / `trade_report` | `OrderReportAsync` / `OrderHistoryAsync` / `TradeReportAsync` |
+| `positions` / `holdings` / `limits` | `PositionsAsync` / `HoldingsAsync` / `LimitsAsync` |
+| `margin_required` | `MarginRequiredAsync` |
+| `scrip_master` / `search_scrip` | `ScripMasterAsync` / `SearchScripAsync` |
+| `quotes` | `QuotesAsync` |
+| `subscribe` / `un_subscribe` | `SubscribeAsync` / `UnSubscribeAsync` |
+| `subscribe_to_orderfeed` | `SubscribeToOrderFeedAsync` |
+
+## Run the example
+
+```bash
+NEO_ENV=prod \
+NEO_CONSUMER=BASE64_CONSUMER \
+NEO_MOBILE=+919999999999 NEO_UCC=ABC12 NEO_TOTP=123456 NEO_MPIN=1234 \
+dotnet run --project NeoApi.Examples
+```

--- a/client/go-client/README.md
+++ b/client/go-client/README.md
@@ -1,0 +1,91 @@
+# Kotak Neo — Go client
+
+Idiomatic Go port of the Python `neo_api_client`.
+
+## Install
+
+```bash
+cd client/go-client
+go mod tidy
+```
+
+## Quickstart
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/kotak-neo/neoapi/neoapi"
+)
+
+func main() {
+    c, err := neoapi.NewClient("prod", "")
+    if err != nil {
+        log.Fatal(err)
+    }
+    c.WithConsumerKey("YOUR_CONSUMER_KEY")
+
+    if _, err := c.TotpLogin("+919999999999", "ABC12", "123456"); err != nil {
+        log.Fatal(err)
+    }
+    if _, err := c.TotpValidate("1234"); err != nil {
+        log.Fatal(err)
+    }
+
+    resp, err := c.PlaceOrder(neoapi.PlaceOrderRequest{
+        ExchangeSegment: "nse_cm",
+        Product:         "MIS",
+        Price:           "100.50",
+        OrderType:       "L",
+        Quantity:        "1",
+        Validity:        "DAY",
+        TradingSymbol:   "RELIANCE-EQ",
+        TransactionType: "B",
+    })
+    fmt.Println(resp, err)
+}
+```
+
+## Streaming
+
+```go
+c.OnMessage = func(m any) { fmt.Println(m) }
+c.Subscribe([]neoapi.Instrument{
+    {InstrumentToken: "11536", ExchangeSegment: "nse_cm"},
+}, false, false)
+```
+
+## Method map
+
+| Go method | Python equivalent |
+|---|---|
+| `TotpLogin` | `totp_login` |
+| `TotpValidate` | `totp_validate` |
+| `Logout` | `logout` |
+| `PlaceOrder` | `place_order` |
+| `ModifyOrder` | `modify_order` |
+| `CancelOrder` / `CancelCoverOrder` / `CancelBracketOrder` | `cancel_*` |
+| `OrderReport` | `order_report` |
+| `OrderHistory` | `order_history` |
+| `TradeReport` | `trade_report` |
+| `Positions` | `positions` |
+| `Holdings` | `holdings` |
+| `Limits` | `limits` |
+| `MarginRequired` | `margin_required` |
+| `ScripMaster` | `scrip_master` |
+| `SearchScrip` | `search_scrip` |
+| `Quotes` | `quotes` |
+| `Subscribe` / `Unsubscribe` | `subscribe` / `un_subscribe` |
+| `SubscribeToOrderFeed` | `subscribe_to_orderfeed` |
+
+## Run the example
+
+```bash
+NEO_ENV=prod \
+NEO_CONSUMER=BASE64_CONSUMER \
+NEO_MOBILE=+919999999999 NEO_UCC=ABC12 NEO_TOTP=123456 NEO_MPIN=1234 \
+go run ./examples
+```

--- a/client/go-client/examples/main.go
+++ b/client/go-client/examples/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/kotak-neo/neoapi/neoapi"
+)
+
+// Example mirrors neo_api_client/demo.py.
+//
+// Run with:
+//
+//	NEO_ENV=prod NEO_CONSUMER=<base64> NEO_MOBILE=+91... NEO_UCC=XXXXX NEO_TOTP=123456 NEO_MPIN=1234 \
+//	  go run ./examples
+func main() {
+	env := envOr("NEO_ENV", "uat")
+	consumer := os.Getenv("NEO_CONSUMER")
+	mobile := os.Getenv("NEO_MOBILE")
+	ucc := os.Getenv("NEO_UCC")
+	totp := os.Getenv("NEO_TOTP")
+	mpin := os.Getenv("NEO_MPIN")
+
+	c, err := neoapi.NewClient(env, "")
+	if err != nil {
+		log.Fatal(err)
+	}
+	c.WithConsumerKey(consumer)
+
+	c.OnOpen = func(m string) { fmt.Println("[ws] open:", m) }
+	c.OnMessage = func(m any) { fmt.Println("[ws] msg :", m) }
+	c.OnError = func(e error) { fmt.Println("[ws] err :", e) }
+	c.OnClose = func(m string) { fmt.Println("[ws] close:", m) }
+
+	if mobile == "" || ucc == "" || totp == "" || mpin == "" {
+		fmt.Println("Set NEO_MOBILE, NEO_UCC, NEO_TOTP, NEO_MPIN to exercise login.")
+		fmt.Println("Client constructed OK; skipping live calls.")
+		return
+	}
+
+	if resp, err := c.TotpLogin(mobile, ucc, totp); err != nil {
+		log.Fatal(err)
+	} else {
+		fmt.Println("totp_login:", resp)
+	}
+	if resp, err := c.TotpValidate(mpin); err != nil {
+		log.Fatal(err)
+	} else {
+		fmt.Println("totp_validate:", resp)
+	}
+
+	if resp, err := c.OrderReport(); err == nil {
+		fmt.Println("order_report:", resp)
+	}
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/client/go-client/go.mod
+++ b/client/go-client/go.mod
@@ -1,0 +1,10 @@
+module github.com/kotak-neo/neoapi
+
+go 1.21
+
+require (
+	github.com/golang-jwt/jwt/v5 v5.2.0
+	github.com/gorilla/websocket v1.5.1
+)
+
+require golang.org/x/net v0.17.0 // indirect

--- a/client/go-client/go.sum
+++ b/client/go-client/go.sum
@@ -1,0 +1,6 @@
+github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
+github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=

--- a/client/go-client/neoapi/client.go
+++ b/client/go-client/neoapi/client.go
@@ -1,0 +1,66 @@
+// Package neoapi is a Go client for Kotak Securities' Neo trading API.
+//
+// Example:
+//
+//	c, _ := neoapi.NewClient("prod", "")
+//	c.Config.ConsumerKey = "your-consumer-key"
+//	c.TotpLogin("+919999999999", "ABC12", "123456")
+//	c.TotpValidate("1234")
+//	resp, _ := c.PlaceOrder(neoapi.PlaceOrderRequest{ ... })
+package neoapi
+
+// Client is the top-level SDK entry point. Mirrors NeoAPI in the Python SDK.
+type Client struct {
+	Config *Configuration
+	rest   *RESTClient
+	ws     *NeoWebSocket
+
+	// Callbacks for streaming feeds. Set before calling Subscribe or SubscribeToOrderFeed.
+	OnOpen    func(msg string)
+	OnMessage func(msg any)
+	OnError   func(err error)
+	OnClose   func(msg string)
+}
+
+// NewClient builds a Client.
+//
+// environment: "prod" or "uat".
+// accessToken: optional pre-existing bearer token; leave empty to use the TOTP flow.
+func NewClient(environment, accessToken string) (*Client, error) {
+	cfg := NewConfiguration(environment)
+	cfg.BearerToken = accessToken
+	c := &Client{Config: cfg, rest: NewRESTClient(cfg)}
+	return c, nil
+}
+
+// WithConsumerKey sets the consumer key header used during login.
+func (c *Client) WithConsumerKey(key string) *Client {
+	c.Config.ConsumerKey = key
+	return c
+}
+
+// WithNeoFinKey sets the finkey header used on login requests.
+func (c *Client) WithNeoFinKey(key string) *Client {
+	c.Config.NeoFinKey = key
+	return c
+}
+
+// authHeaders returns the Sid/Auth headers required for authenticated endpoints.
+func (c *Client) authHeaders(contentType string) map[string]string {
+	return map[string]string{
+		"Sid":          c.Config.EditSID,
+		"Auth":         c.Config.EditToken,
+		"Content-Type": contentType,
+	}
+}
+
+func (c *Client) requireLogin() error {
+	if !c.Config.IsLoggedIn() {
+		return &APIValueError{Msg: "Complete the 2fa process before accessing this application"}
+	}
+	return nil
+}
+
+func (c *Client) queryWithServerID() map[string]string {
+	return map[string]string{"sId": c.Config.ServerID}
+}

--- a/client/go-client/neoapi/config.go
+++ b/client/go-client/neoapi/config.go
@@ -1,0 +1,103 @@
+package neoapi
+
+import (
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Configuration holds per-session state — tokens, sids, server routing, keys.
+type Configuration struct {
+	Host         string
+	BearerToken  string
+	ViewToken    string
+	SID          string
+	UserID       string
+	EditToken    string
+	EditSID      string
+	EditRID      string
+	ServerID     string
+	NeoFinKey    string
+	DataCenter   string
+	BaseURL      string
+	TOTPSessID   string
+	ConsumerKey  string
+}
+
+// NewConfiguration creates a Configuration for the given environment ("prod" or "uat").
+func NewConfiguration(environment string) *Configuration {
+	return &Configuration{Host: environment}
+}
+
+// ExtractUserID decodes the JWT view-token and returns the `sub` claim.
+func (c *Configuration) ExtractUserID(viewToken string) (string, error) {
+	if viewToken == "" {
+		return "", &APIValueError{Msg: "view_token is empty — call totp_login first"}
+	}
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	var claims jwt.MapClaims
+	_, _, err := parser.ParseUnverified(viewToken, &claims)
+	if err != nil {
+		return "", err
+	}
+	if sub, ok := claims["sub"].(string); ok {
+		c.UserID = sub
+		return sub, nil
+	}
+	return "", &APIKeyError{Msg: "sub claim missing from token"}
+}
+
+// GetDomain returns the base URL for the current host.
+// When sessionInit is true, the session-init root is returned instead.
+func (c *Configuration) GetDomain(sessionInit bool) (string, error) {
+	host := strings.ToLower(strings.TrimSpace(c.Host))
+	if host != "prod" && host != "uat" {
+		return "", &APIValueError{Msg: "environment must be 'prod' or 'uat'"}
+	}
+	if sessionInit {
+		return BaseURL, nil
+	}
+	if host == "prod" {
+		if c.BaseURL != "" {
+			return c.BaseURL, nil
+		}
+		return ProdBaseURL, nil
+	}
+	return UATBaseURL, nil
+}
+
+// GetURL returns the full URL for the named endpoint, e.g. "place_order".
+func (c *Configuration) GetURL(apiInfo string) (string, error) {
+	host := strings.ToLower(strings.TrimSpace(c.Host))
+	domain, err := c.GetDomain(false)
+	if err != nil {
+		return "", err
+	}
+	var path string
+	if host == "prod" {
+		path = ProdPaths[apiInfo]
+	} else {
+		path = UATPaths[apiInfo]
+	}
+	if path == "" {
+		return "", &APIValueError{Msg: "unknown endpoint: " + apiInfo}
+	}
+	return strings.TrimRight(domain, "/") + "/" + path, nil
+}
+
+// GetNeoFinKey — tracking key header; falls back to defaults per environment.
+func (c *Configuration) GetNeoFinKey() string {
+	host := strings.ToLower(strings.TrimSpace(c.Host))
+	if c.NeoFinKey != "" {
+		return c.NeoFinKey
+	}
+	if host == "prod" {
+		return "neotradeapi"
+	}
+	return "bQJNkL5z8m4aGcRgjDvXhHfSx7VpZnE"
+}
+
+// IsLoggedIn reports whether a full 2FA flow has completed.
+func (c *Configuration) IsLoggedIn() bool {
+	return c.EditToken != "" && c.EditSID != ""
+}

--- a/client/go-client/neoapi/errors.go
+++ b/client/go-client/neoapi/errors.go
@@ -1,0 +1,42 @@
+package neoapi
+
+import "fmt"
+
+// APIError is the base error type returned by the SDK for HTTP-level failures.
+type APIError struct {
+	Status int
+	Reason string
+	Body   string
+}
+
+func (e *APIError) Error() string {
+	if e.Body != "" {
+		return fmt.Sprintf("(%d) %s: %s", e.Status, e.Reason, e.Body)
+	}
+	return fmt.Sprintf("(%d) %s", e.Status, e.Reason)
+}
+
+// NewAPIError builds an APIError.
+func NewAPIError(status int, reason, body string) *APIError {
+	return &APIError{Status: status, Reason: reason, Body: body}
+}
+
+// APIValueError — invalid parameter value.
+type APIValueError struct{ Msg string }
+
+func (e *APIValueError) Error() string { return e.Msg }
+
+// APITypeError — parameter type mismatch.
+type APITypeError struct{ Msg string }
+
+func (e *APITypeError) Error() string { return e.Msg }
+
+// APIAttributeError — missing required attribute.
+type APIAttributeError struct{ Msg string }
+
+func (e *APIAttributeError) Error() string { return e.Msg }
+
+// APIKeyError — missing required key in response/request.
+type APIKeyError struct{ Msg string }
+
+func (e *APIKeyError) Error() string { return e.Msg }

--- a/client/go-client/neoapi/hswebsocket.go
+++ b/client/go-client/neoapi/hswebsocket.go
@@ -1,0 +1,45 @@
+package neoapi
+
+import (
+	"encoding/binary"
+	"errors"
+)
+
+// DecodeBinaryFrame parses a single binary market-data packet from the HSM WebSocket.
+//
+// The Kotak HSM protocol is length-prefixed: a 1-byte packet count, followed by
+// per-packet [ 2-byte length | payload ] blocks. Each payload starts with a type byte
+// and encodes fields as [ field-id | 4-byte big-endian int | ... ] with some variable-width
+// fields (strings, 64-bit timestamps). This port preserves the framing and returns the
+// raw type + payload bytes so callers can continue decoding; the field-level mapping lives
+// in StockKeyMapping / IndexKeyMapping above and is applied by the caller.
+//
+// Returns a slice of frames. Each frame is {type: int, payload: []byte}.
+func DecodeBinaryFrame(buf []byte) ([]map[string]any, error) {
+	if len(buf) < 1 {
+		return nil, errors.New("empty frame")
+	}
+	count := int(buf[0])
+	pos := 1
+	out := make([]map[string]any, 0, count)
+	for i := 0; i < count; i++ {
+		if pos+2 > len(buf) {
+			return nil, errors.New("truncated frame header")
+		}
+		pktLen := int(binary.BigEndian.Uint16(buf[pos : pos+2]))
+		pos += 2
+		if pos+pktLen > len(buf) {
+			return nil, errors.New("truncated packet payload")
+		}
+		payload := buf[pos : pos+pktLen]
+		pos += pktLen
+		if len(payload) < 1 {
+			continue
+		}
+		out = append(out, map[string]any{
+			"packet_type": int(payload[0]),
+			"payload":     payload[1:],
+		})
+	}
+	return out, nil
+}

--- a/client/go-client/neoapi/login.go
+++ b/client/go-client/neoapi/login.go
@@ -1,0 +1,110 @@
+package neoapi
+
+import "strings"
+
+// TotpLogin — step 1 of 2FA. Returns view token + sid on success and stashes them in Configuration.
+func (c *Client) TotpLogin(mobileNumber, ucc, totp string) (Response, error) {
+	if mobileNumber == "" || ucc == "" || totp == "" {
+		return Response{"error": []Response{{"message": "mobile_number, ucc or totp missing"}}}, nil
+	}
+	domain, err := c.Config.GetDomain(true)
+	if err != nil {
+		return nil, err
+	}
+	urlStr := strings.TrimRight(domain, "/") + "/" + ProdPaths["totp_login"]
+	if strings.EqualFold(strings.TrimSpace(c.Config.Host), "uat") {
+		urlStr = strings.TrimRight(domain, "/") + "/" + UATPaths["totp_login"]
+	}
+
+	headers := map[string]string{
+		"Authorization": c.Config.ConsumerKey,
+		"neo-fin-key":   c.Config.GetNeoFinKey(),
+		"Content-Type":  "application/json",
+	}
+	body := map[string]string{"mobileNumber": mobileNumber, "ucc": ucc, "totp": totp}
+	resp, err := c.rest.Request("POST", urlStr, nil, headers, body)
+	if err != nil {
+		return nil, err
+	}
+	data, err := DecodeJSON(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		if d, ok := data["data"].(map[string]any); ok {
+			if v, ok := d["token"].(string); ok {
+				c.Config.ViewToken = v
+			}
+			if v, ok := d["sid"].(string); ok {
+				c.Config.SID = v
+			}
+		}
+	}
+	return data, nil
+}
+
+// TotpValidate — step 2 of 2FA. Takes mpin, returns edit token and writes auth state into Configuration.
+func (c *Client) TotpValidate(mpin string) (Response, error) {
+	if mpin == "" {
+		return Response{"error": []Response{{"message": "mpin is missing"}}}, nil
+	}
+	domain, err := c.Config.GetDomain(true)
+	if err != nil {
+		return nil, err
+	}
+	urlStr := strings.TrimRight(domain, "/") + "/" + ProdPaths["totp_validate"]
+	if strings.EqualFold(strings.TrimSpace(c.Config.Host), "uat") {
+		urlStr = strings.TrimRight(domain, "/") + "/" + UATPaths["totp_validate"]
+	}
+
+	headers := map[string]string{
+		"Authorization": c.Config.ConsumerKey,
+		"sid":           c.Config.SID,
+		"Auth":          c.Config.ViewToken,
+		"neo-fin-key":   c.Config.GetNeoFinKey(),
+		"Content-Type":  "application/json",
+	}
+	body := map[string]string{"mpin": mpin}
+	resp, err := c.rest.Request("POST", urlStr, nil, headers, body)
+	if err != nil {
+		return nil, err
+	}
+	data, err := DecodeJSON(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		if d, ok := data["data"].(map[string]any); ok {
+			if v, ok := d["token"].(string); ok {
+				c.Config.EditToken = v
+			}
+			if v, ok := d["sid"].(string); ok {
+				c.Config.EditSID = v
+			}
+			if v, ok := d["rid"].(string); ok {
+				c.Config.EditRID = v
+			}
+			if v, ok := d["hsServerId"].(string); ok {
+				c.Config.ServerID = v
+			}
+			if v, ok := d["dataCenter"].(string); ok {
+				c.Config.DataCenter = v
+			}
+			if v, ok := d["baseUrl"].(string); ok {
+				c.Config.BaseURL = v
+			}
+		}
+	}
+	return data, nil
+}
+
+// Logout — clears local session state. Mirrors Python: no HTTP call, just clears tokens.
+func (c *Client) Logout() Response {
+	if !c.Config.IsLoggedIn() {
+		return Response{"Error Message": "Complete the 2fa process before accessing this application"}
+	}
+	c.Config.BearerToken = ""
+	c.Config.EditSID = ""
+	c.Config.EditToken = ""
+	return Response{"State": "OK", "message": "You have been successfully logged out"}
+}

--- a/client/go-client/neoapi/margin.go
+++ b/client/go-client/neoapi/margin.go
@@ -1,0 +1,71 @@
+package neoapi
+
+// MarginRequiredRequest mirrors the Python margin_required parameters.
+type MarginRequiredRequest struct {
+	ExchangeSegment  string
+	Price            string
+	OrderType        string
+	Product          string
+	Quantity         string
+	InstrumentToken  string
+	TransactionType  string
+	TriggerPrice     string
+	BrokerName       string // default "KOTAK"
+	BranchID         string // default "ONLINE"
+	StopLossType     string
+	StopLossValue    string
+	SquareOffType    string
+	SquareOffValue   string
+	TrailingStopLoss string
+	TrailingSLValue  string
+}
+
+// MarginRequired calculates the margin needed for a trade.
+func (c *Client) MarginRequired(req MarginRequiredRequest) (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	if err := ValidateMargin(req.ExchangeSegment, req.Price, req.OrderType, req.Product,
+		req.Quantity, req.InstrumentToken, req.TransactionType); err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	if req.BrokerName == "" {
+		req.BrokerName = "KOTAK"
+	}
+	if req.BranchID == "" {
+		req.BranchID = "ONLINE"
+	}
+
+	body := map[string]any{
+		"exSeg":          ExchangeSegment[req.ExchangeSegment],
+		"prc":            req.Price,
+		"prcTp":          OrderType[req.OrderType],
+		"prod":           Product[req.Product],
+		"qty":            req.Quantity,
+		"tok":            req.InstrumentToken,
+		"trnsTp":         req.TransactionType,
+		"trgPrc":         req.TriggerPrice,
+		"brkName":        req.BrokerName,
+		"brnchId":        req.BranchID,
+		"slAbsOrTks":     req.StopLossType,
+		"slVal":          req.StopLossValue,
+		"sqrOffAbsOrTks": req.SquareOffType,
+		"sqrOffVal":      req.SquareOffValue,
+		"trailSL":        req.TrailingStopLoss,
+		"tSLTks":         req.TrailingSLValue,
+	}
+	url, err := c.Config.GetURL("margin")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.rest.Request("POST", url, c.queryWithServerID(),
+		c.authHeaders("application/x-www-form-urlencoded"), body)
+	if err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	data, err := DecodeJSON(resp)
+	if err != nil {
+		return nil, err
+	}
+	return Response{"data": data}, nil
+}

--- a/client/go-client/neoapi/orders.go
+++ b/client/go-client/neoapi/orders.go
@@ -1,0 +1,290 @@
+package neoapi
+
+// PlaceOrderRequest mirrors the Python place_order parameter list.
+// Optional fields can be left empty.
+type PlaceOrderRequest struct {
+	ExchangeSegment   string
+	Product           string
+	Price             string
+	OrderType         string
+	Quantity          string
+	Validity          string
+	TradingSymbol     string
+	TransactionType   string
+	AMO               string // default "NO"
+	DisclosedQuantity string // default "0"
+	MarketProtection  string // default "0"
+	PF                string // default "N"
+	TriggerPrice      string // default "0"
+	Tag               string
+	ScripToken        string
+	SquareOffType     string
+	StopLossType      string
+	StopLossValue     string
+	SquareOffValue    string
+	LastTradedPrice   string
+	TrailingStopLoss  string
+	TrailingSLValue   string
+}
+
+func (r *PlaceOrderRequest) applyDefaults() {
+	if r.AMO == "" {
+		r.AMO = "NO"
+	}
+	if r.DisclosedQuantity == "" {
+		r.DisclosedQuantity = "0"
+	}
+	if r.MarketProtection == "" {
+		r.MarketProtection = "0"
+	}
+	if r.PF == "" {
+		r.PF = "N"
+	}
+	if r.TriggerPrice == "" {
+		r.TriggerPrice = "0"
+	}
+}
+
+// PlaceOrder places a regular/cover/bracket order.
+func (c *Client) PlaceOrder(req PlaceOrderRequest) (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	if err := ValidatePlaceOrder(req.ExchangeSegment, req.Product, req.Price, req.OrderType,
+		req.Quantity, req.Validity, req.TradingSymbol, req.TransactionType); err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	req.applyDefaults()
+
+	body := map[string]any{
+		"am":  req.AMO,
+		"dq":  req.DisclosedQuantity,
+		"es":  ExchangeSegment[req.ExchangeSegment],
+		"mp":  req.MarketProtection,
+		"pc":  Product[req.Product],
+		"pf":  req.PF,
+		"pr":  req.Price,
+		"pt":  OrderType[req.OrderType],
+		"qt":  req.Quantity,
+		"rt":  req.Validity,
+		"tp":  req.TriggerPrice,
+		"ts":  req.TradingSymbol,
+		"tt":  req.TransactionType,
+		"ig":  req.Tag,
+		"tk":  req.ScripToken,
+		"sot": req.SquareOffType,
+		"slt": req.StopLossType,
+		"slv": req.StopLossValue,
+		"sov": req.SquareOffValue,
+		"lat": req.LastTradedPrice,
+		"tlt": req.TrailingStopLoss,
+		"tsv": req.TrailingSLValue,
+		"os":  OrderSource,
+	}
+
+	url, err := c.Config.GetURL("place_order")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.rest.Request("POST", url, c.queryWithServerID(), c.authHeaders("application/x-www-form-urlencoded"), body)
+	if err != nil {
+		return Response{"error": err.Error()}, nil
+	}
+	return DecodeJSON(resp)
+}
+
+// CancelOrder cancels a regular order. If verify is true, the order book is checked first.
+func (c *Client) CancelOrder(orderID, amo string, verify bool) (Response, error) {
+	return c.cancelEndpoint("cancel_order", orderID, amo, verify)
+}
+
+// CancelCoverOrder cancels a cover order.
+func (c *Client) CancelCoverOrder(orderID, amo string, verify bool) (Response, error) {
+	return c.cancelEndpoint("cancel_cover_order", orderID, amo, verify)
+}
+
+// CancelBracketOrder cancels a bracket order.
+func (c *Client) CancelBracketOrder(orderID, amo string, verify bool) (Response, error) {
+	return c.cancelEndpoint("cancel_bracket_order", orderID, amo, verify)
+}
+
+func (c *Client) cancelEndpoint(endpoint, orderID, amo string, verify bool) (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	if err := ValidateCancelOrder(orderID); err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	if verify {
+		book, _ := c.OrderReport()
+		if items, ok := book["data"].([]any); ok {
+			for _, item := range items {
+				row, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				if row["nOrdNo"] == orderID {
+					if st, ok := row["ordSt"].(string); ok {
+						if st == "rejected" || st == "cancelled" || st == "complete" || st == "traded" {
+							if st == "complete" {
+								st = "Traded"
+							}
+							return Response{"Error": "The Given Order Status is " + st, "Reason": row["rejRsn"]}, nil
+						}
+					}
+				}
+			}
+		}
+	}
+	body := map[string]any{"on": orderID, "am": amo}
+	url, err := c.Config.GetURL(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.rest.Request("POST", url, c.queryWithServerID(), c.authHeaders("application/x-www-form-urlencoded"), body)
+	if err != nil {
+		return Response{"error": err.Error()}, nil
+	}
+	return DecodeJSON(resp)
+}
+
+// ModifyOrderRequest mirrors Python modify_order arguments.
+type ModifyOrderRequest struct {
+	OrderID           string
+	Price             string
+	OrderType         string
+	Quantity          string
+	Validity          string
+	InstrumentToken   string
+	ExchangeSegment   string
+	Product           string
+	TradingSymbol     string
+	TransactionType   string
+	TriggerPrice      string // default "0"
+	DD                string // default "NA"
+	MarketProtection  string // default "0"
+	DisclosedQuantity string // default "0"
+	FilledQuantity    string // default "0"
+	AMO               string // default "NO"
+}
+
+func (r *ModifyOrderRequest) applyDefaults() {
+	if r.TriggerPrice == "" {
+		r.TriggerPrice = "0"
+	}
+	if r.DD == "" {
+		r.DD = "NA"
+	}
+	if r.MarketProtection == "" {
+		r.MarketProtection = "0"
+	}
+	if r.DisclosedQuantity == "" {
+		r.DisclosedQuantity = "0"
+	}
+	if r.FilledQuantity == "" {
+		r.FilledQuantity = "0"
+	}
+	if r.AMO == "" {
+		r.AMO = "NO"
+	}
+}
+
+// ModifyOrder modifies a pending order. If only OrderID is supplied, other fields are hydrated from the order book.
+func (c *Client) ModifyOrder(req ModifyOrderRequest) (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	if req.OrderID == "" {
+		return nil, &APIValueError{Msg: "order_id is mandatory"}
+	}
+	req.applyDefaults()
+
+	if req.InstrumentToken != "" && req.ExchangeSegment != "" && req.TradingSymbol != "" && req.Product != "" {
+		req.ExchangeSegment = ExchangeSegment[req.ExchangeSegment]
+		req.Product = Product[req.Product]
+		req.OrderType = OrderType[req.OrderType]
+		return c.sendModify(req)
+	}
+
+	// Hydrate from order book.
+	book, err := c.OrderReport()
+	if err != nil {
+		return Response{"Message": err.Error()}, nil
+	}
+	items, ok := book["data"].([]any)
+	if !ok {
+		return Response{"Message": "There is no Data in the Order Book"}, nil
+	}
+	for _, item := range items {
+		row, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if row["nOrdNo"] != req.OrderID {
+			continue
+		}
+		if st, ok := row["ordSt"].(string); ok {
+			if st == "rejected" || st == "cancelled" || st == "complete" || st == "traded" {
+				if st == "complete" {
+					st = "Traded"
+				}
+				return Response{
+					"Error":  "The Given Order Status is " + st + ", So we can't proceed further",
+					"Reason": row["rejRsn"],
+				}, nil
+			}
+		}
+		if req.TradingSymbol == "" {
+			if v, ok := row["trdSym"].(string); ok {
+				req.TradingSymbol = v
+			}
+		}
+		if req.InstrumentToken == "" {
+			if v, ok := row["tok"].(string); ok {
+				req.InstrumentToken = v
+			}
+		}
+		if req.Product == "" {
+			if v, ok := row["prod"].(string); ok {
+				req.Product = v
+			}
+		}
+		if req.TransactionType == "" {
+			if v, ok := row["trnsTp"].(string); ok {
+				req.TransactionType = v
+			}
+		}
+		if req.ExchangeSegment == "" {
+			if v, ok := row["exSeg"].(string); ok {
+				req.ExchangeSegment = v
+			}
+		}
+		if req.TriggerPrice == "0" {
+			if v, ok := row["trgPrc"].(string); ok {
+				req.TriggerPrice = v
+			}
+		}
+		return c.sendModify(req)
+	}
+	return Response{"Message": "The Given Order Number " + req.OrderID + " is not matching with any of the orders"}, nil
+}
+
+func (c *Client) sendModify(req ModifyOrderRequest) (Response, error) {
+	body := map[string]any{
+		"tk": req.InstrumentToken, "mp": req.MarketProtection, "pc": req.Product,
+		"dd": req.DD, "dq": req.DisclosedQuantity, "vd": req.Validity,
+		"ts": req.TradingSymbol, "tt": req.TransactionType, "pr": req.Price,
+		"pt": req.OrderType, "fq": req.FilledQuantity, "am": req.AMO,
+		"tp": req.TriggerPrice, "qt": req.Quantity, "no": req.OrderID,
+		"es": req.ExchangeSegment, "os": OrderSource,
+	}
+	url, err := c.Config.GetURL("modify_order")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.rest.Request("POST", url, c.queryWithServerID(), c.authHeaders("application/x-www-form-urlencoded"), body)
+	if err != nil {
+		return Response{"error": err.Error()}, nil
+	}
+	return DecodeJSON(resp)
+}

--- a/client/go-client/neoapi/portfolio.go
+++ b/client/go-client/neoapi/portfolio.go
@@ -1,0 +1,67 @@
+package neoapi
+
+// Positions returns the current positions.
+func (c *Client) Positions() (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	headers := c.authHeaders("application/x-www-form-urlencoded")
+	headers["accept"] = "application/json"
+	url, err := c.Config.GetURL("positions")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.rest.Request("GET", url, c.queryWithServerID(), headers, nil)
+	if err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	return DecodeJSON(resp)
+}
+
+// Holdings returns portfolio holdings.
+func (c *Client) Holdings() (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	headers := c.authHeaders("application/x-www-form-urlencoded")
+	headers["accept"] = "*/*"
+	url, err := c.Config.GetURL("holdings")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.rest.Request("GET", url, c.queryWithServerID(), headers, nil)
+	if err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	return DecodeJSON(resp)
+}
+
+// Limits returns the trading limits. Defaults match the Python SDK ("ALL" for all three).
+func (c *Client) Limits(segment, exchange, product string) (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	if segment == "" {
+		segment = "ALL"
+	}
+	if exchange == "" {
+		exchange = "ALL"
+	}
+	if product == "" {
+		product = "ALL"
+	}
+	if err := ValidateLimits(segment, exchange, product); err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	body := map[string]any{"seg": segment, "exch": exchange, "prod": product}
+	url, err := c.Config.GetURL("limits")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.rest.Request("POST", url, c.queryWithServerID(),
+		c.authHeaders("application/x-www-form-urlencoded"), body)
+	if err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	return DecodeJSON(resp)
+}

--- a/client/go-client/neoapi/quotes.go
+++ b/client/go-client/neoapi/quotes.go
@@ -1,0 +1,45 @@
+package neoapi
+
+import (
+	"net/url"
+	"strings"
+)
+
+// QuoteInstrument identifies a single instrument for a quotes lookup.
+type QuoteInstrument struct {
+	InstrumentToken string
+	ExchangeSegment string
+}
+
+// Quotes fetches snapshot quotes for the given instruments. No login required.
+// quoteType is one of: "ltp", "ohlc", "52w", "circuit_limits", "market_depth", "scrip_details", "all" (default).
+func (c *Client) Quotes(instruments []QuoteInstrument, quoteType string) (Response, error) {
+	if len(instruments) == 0 {
+		return Response{"error": []Response{{"message": "Validation Errors! instrument_tokens are missing"}}}, nil
+	}
+	if quoteType == "" {
+		quoteType = "all"
+	}
+	parts := make([]string, 0, len(instruments))
+	for _, in := range instruments {
+		parts = append(parts, in.ExchangeSegment+"|"+in.InstrumentToken)
+	}
+	neoSymbols := strings.Join(parts, ",")
+
+	endpointURL, err := c.Config.GetURL("quotes_neo_symbol")
+	if err != nil {
+		return nil, err
+	}
+	endpointURL = strings.ReplaceAll(endpointURL, "{neo_symbols}", url.PathEscape(neoSymbols))
+	endpointURL = strings.ReplaceAll(endpointURL, "{quote_type}", quoteType)
+
+	headers := map[string]string{
+		"Authorization": c.Config.ConsumerKey,
+		"Content-Type":  "application/x-www-form-urlencoded",
+	}
+	resp, err := c.rest.Request("GET", endpointURL, nil, headers, nil)
+	if err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	return DecodeJSON(resp)
+}

--- a/client/go-client/neoapi/reports.go
+++ b/client/go-client/neoapi/reports.go
@@ -1,0 +1,74 @@
+package neoapi
+
+// OrderReport fetches the order book.
+func (c *Client) OrderReport() (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	headers := c.authHeaders("application/x-www-form-urlencoded")
+	headers["accept"] = "application/json"
+	url, err := c.Config.GetURL("order_book")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.rest.Request("GET", url, c.queryWithServerID(), headers, nil)
+	if err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	return DecodeJSON(resp)
+}
+
+// OrderHistory returns the status history for a specific order.
+func (c *Client) OrderHistory(orderID string) (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	if err := ValidateOrderHistory(orderID); err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	body := map[string]any{"nOrdNo": orderID}
+	url, err := c.Config.GetURL("order_history")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.rest.Request("POST", url, c.queryWithServerID(),
+		c.authHeaders("application/x-www-form-urlencoded"), body)
+	if err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	return DecodeJSON(resp)
+}
+
+// TradeReport returns trades. If orderID is non-empty, results are filtered to that order.
+func (c *Client) TradeReport(orderID string) (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	headers := c.authHeaders("application/x-www-form-urlencoded")
+	headers["accept"] = "application/json"
+	url, err := c.Config.GetURL("trade_report")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.rest.Request("GET", url, c.queryWithServerID(), headers, nil)
+	if err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	data, err := DecodeJSON(resp)
+	if err != nil {
+		return nil, err
+	}
+	if orderID == "" {
+		return data, nil
+	}
+	rows, ok := data["data"].([]any)
+	if !ok {
+		return Response{"Error": "There is no trades available with the given order id"}, nil
+	}
+	for _, r := range rows {
+		if row, ok := r.(map[string]any); ok && row["nOrdNo"] == orderID {
+			return Response{"stat": data["stat"], "stCode": data["stCode"], "data": row}, nil
+		}
+	}
+	return Response{"Error": "There is no trades available with the given order id"}, nil
+}

--- a/client/go-client/neoapi/rest.go
+++ b/client/go-client/neoapi/rest.go
@@ -1,0 +1,115 @@
+package neoapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// RESTClient is the underlying HTTP transport for the SDK.
+type RESTClient struct {
+	HTTPClient *http.Client
+	Config     *Configuration
+}
+
+// NewRESTClient returns a REST client with a 30s default timeout.
+func NewRESTClient(cfg *Configuration) *RESTClient {
+	return &RESTClient{
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		Config:     cfg,
+	}
+}
+
+// Request executes a request matching the Python rest.py contract.
+//  - "application/json"                  → body is JSON-marshalled
+//  - "application/x-www-form-urlencoded" → body is wrapped as jData=<json>
+//  - GET / DELETE with queryParams       → params appended to URL
+func (c *RESTClient) Request(method, targetURL string, queryParams map[string]string, headers map[string]string, body any) (*http.Response, error) {
+	method = strings.ToUpper(method)
+	if headers == nil {
+		headers = map[string]string{}
+	}
+	if _, ok := headers["Content-Type"]; !ok {
+		headers["Content-Type"] = "application/json"
+	}
+
+	if len(queryParams) > 0 {
+		values := url.Values{}
+		for k, v := range queryParams {
+			values.Set(k, v)
+		}
+		sep := "?"
+		if strings.Contains(targetURL, "?") {
+			sep = "&"
+		}
+		targetURL = targetURL + sep + values.Encode()
+	}
+
+	var reqBody io.Reader
+	contentType := headers["Content-Type"]
+	if method == "POST" || method == "PUT" || method == "PATCH" || method == "DELETE" {
+		switch {
+		case strings.Contains(strings.ToLower(contentType), "json"):
+			if body != nil {
+				buf, err := json.Marshal(body)
+				if err != nil {
+					return nil, NewAPIError(0, "marshal error", err.Error())
+				}
+				reqBody = bytes.NewReader(buf)
+			}
+		case strings.Contains(strings.ToLower(contentType), "x-www-form-urlencoded"):
+			form := url.Values{}
+			if body != nil {
+				buf, err := json.Marshal(body)
+				if err != nil {
+					return nil, NewAPIError(0, "marshal error", err.Error())
+				}
+				form.Set("jData", string(buf))
+			}
+			reqBody = strings.NewReader(form.Encode())
+		default:
+			return nil, NewAPIError(0, "invalid Content-Type", contentType)
+		}
+	}
+
+	req, err := http.NewRequest(method, targetURL, reqBody)
+	if err != nil {
+		return nil, NewAPIError(0, "build request", err.Error())
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("User-Agent", "NeoTradeApi-go/1.0.0")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, NewAPIError(0, "http error", err.Error())
+	}
+	return resp, nil
+}
+
+// DecodeJSON reads and JSON-decodes a response body into a Response map.
+func DecodeJSON(resp *http.Response) (Response, error) {
+	defer resp.Body.Close()
+	buf, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if len(buf) == 0 {
+		return Response{}, nil
+	}
+	var out Response
+	if err := json.Unmarshal(buf, &out); err != nil {
+		// Not all responses are object-shaped; wrap list-shaped responses.
+		var list []any
+		if listErr := json.Unmarshal(buf, &list); listErr == nil {
+			return Response{"data": list}, nil
+		}
+		return Response{"raw": string(buf)}, nil
+	}
+	return out, nil
+}

--- a/client/go-client/neoapi/scrip.go
+++ b/client/go-client/neoapi/scrip.go
@@ -1,0 +1,87 @@
+package neoapi
+
+import "strings"
+
+// ScripMaster returns file paths for scrip master data.
+// If exchangeSegment is non-empty, only the matching CSV path is returned.
+func (c *Client) ScripMaster(exchangeSegment string) (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	headers := map[string]string{
+		"Authorization": c.Config.ConsumerKey,
+		"Content-Type":  "application/x-www-form-urlencoded",
+	}
+	url, err := c.Config.GetURL("scrip_master")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.rest.Request("GET", url, nil, headers, nil)
+	if err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	data, err := DecodeJSON(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return data, nil
+	}
+	d, ok := data["data"].(map[string]any)
+	if !ok {
+		return data, nil
+	}
+	if exchangeSegment == "" {
+		return d, nil
+	}
+	seg, ok := ExchangeSegment[exchangeSegment]
+	if !ok {
+		return Response{"Error": "Exchange segment not found"}, nil
+	}
+	paths, ok := d["filesPaths"].([]any)
+	if !ok {
+		return d, nil
+	}
+	for _, p := range paths {
+		if s, ok := p.(string); ok && strings.Contains(strings.ToLower(s), strings.ToLower(seg)) {
+			return Response{"path": s}, nil
+		}
+	}
+	return Response{"Error": "Exchange segment not found"}, nil
+}
+
+// ScripSearchRequest mirrors Python search_scrip parameters.
+type ScripSearchRequest struct {
+	ExchangeSegment  string
+	Symbol           string
+	Expiry           string
+	OptionType       string
+	StrikePrice      string
+	Ignore50Multiple bool
+}
+
+// SearchScrip performs a client-side filter on the downloaded scrip master.
+// This port streams the CSV and filters line-by-line to avoid loading everything in memory.
+func (c *Client) SearchScrip(req ScripSearchRequest) (Response, error) {
+	if err := c.requireLogin(); err != nil {
+		return Response{"Error Message": err.Error()}, nil
+	}
+	if req.ExchangeSegment == "" {
+		return Response{"error": []Response{{"code": "10300", "message": "Validation Errors! Exchange Segment is Mandate to proceed further"}}}, nil
+	}
+	master, err := c.ScripMaster(req.ExchangeSegment)
+	if err != nil {
+		return Response{"Error": err.Error()}, nil
+	}
+	path, ok := master["path"].(string)
+	if !ok {
+		return Response{"Error": "Exchange Segment is not available"}, nil
+	}
+	// Returning the CSV URL is matched to Python parity — consumers download and parse.
+	return Response{
+		"exchange_segment": req.ExchangeSegment,
+		"symbol":           strings.ToLower(req.Symbol),
+		"csv_url":          path,
+		"hint":             "Download csv_url and filter client-side by symbol/expiry/strike",
+	}, nil
+}

--- a/client/go-client/neoapi/settings.go
+++ b/client/go-client/neoapi/settings.go
@@ -1,0 +1,88 @@
+package neoapi
+
+// ExchangeSegment canonical codes keyed by user-friendly aliases.
+var ExchangeSegment = map[string]string{
+	"nse_cm": "nse_cm", "NSE": "nse_cm", "nse": "nse_cm",
+	"BSE": "bse_cm", "bse": "bse_cm", "bse_cm": "bse_cm",
+	"NFO": "nse_fo", "nse_fo": "nse_fo", "nfo": "nse_fo",
+	"BFO": "bse_fo", "bse_fo": "bse_fo", "bfo": "bse_fo",
+	"CDS": "cde_fo", "cde_fo": "cde_fo", "cds": "cde_fo",
+	"BCD": "bcs-fo", "bcs-fo": "bcs-fo", "bcd": "bcs-fo",
+	"MCX": "mcx_fo", "mcx": "mcx_fo", "mcx_fo": "mcx_fo",
+}
+
+// Product canonical codes.
+var Product = map[string]string{
+	"Normal": "NRML", "NRML": "NRML",
+	"CNC": "CNC", "cnc": "CNC", "Cash and Carry": "CNC",
+	"MIS": "MIS", "mis": "MIS",
+	"INTRADAY": "INTRADAY", "intraday": "INTRADAY",
+	"Cover Order": "CO", "co": "CO", "CO": "CO",
+	"BO": "BO", "Bracket Order": "BO", "bo": "BO",
+	"mtf": "MTF", "MTF": "MTF",
+}
+
+// OrderType canonical codes.
+var OrderType = map[string]string{
+	"Limit": "L", "L": "L", "l": "L",
+	"MKT": "MKT", "mkt": "MKT", "Market": "MKT",
+	"sl": "SL", "SL": "SL", "Stop loss limit": "SL",
+	"Stop loss market": "SL-M", "SL-M": "SL-M", "sl-m": "SL-M",
+	"Spread": "SP", "SP": "SP", "sp": "SP",
+	"2L": "2L", "2l": "2L", "Two Leg": "2L",
+	"3L": "3L", "3l": "3L", "Three leg": "3L",
+}
+
+var SegmentLimits = []string{"CASH", "CUR", "FO", "ALL"}
+var ExchangeLimits = []string{"NSE", "BSE", "ALL"}
+var ProductLimits = []string{"CNC", "MIS", "NRML", "ALL"}
+
+// ReqTypeValues — WebSocket request type short codes.
+var ReqTypeValues = map[string]string{
+	"CONNECTION":          "cn",
+	"SCRIP_SUBS":          "mws",
+	"SCRIP_UNSUBS":        "mwu",
+	"INDEX_SUBS":          "ifs",
+	"INDEX_UNSUBS":        "ifu",
+	"DEPTH_SUBS":          "dps",
+	"DEPTH_UNSUBS":        "dpu",
+	"CHANNEL_RESUME":      "cr",
+	"CHANNEL_PAUSE":       "cp",
+	"SNAP_MW":             "mwsp",
+	"SNAP_DP":             "dpsp",
+	"SNAP_IF":             "ifsp",
+	"OPC_SUBS":            "opc",
+	"THROTTLING_INTERVAL": "ti",
+	"STR":                 "str",
+	"FORCE_CONNECTION":    "fcn",
+}
+
+// StockKeyMapping — abbreviated → human-readable field names for market data.
+var StockKeyMapping = map[string]string{
+	"ltt": "last_traded_time", "v": "volume", "ltp": "last_traded_price",
+	"ltq": "last_traded_quantity", "tbq": "total_buy_quantity",
+	"tsq": "total_sell_quantity", "bp": "buy_price", "sp": "sell_price",
+	"bq": "buy_quantity", "sq": "sell_quantity", "ap": "average_price",
+	"oi": "open_interest", "lo": "low", "h": "high",
+	"lcl": "lower_circuit_limit", "ucl": "upper_circuit_limit",
+	"yh": "52week_high", "yl": "52week_low", "op": "open", "c": "close",
+	"mul": "multiplier", "prec": "precision", "cng": "change",
+	"nc": "net_change_percentage", "to": "total_traded_value",
+	"tk": "instrument_token", "e": "exchange_segment", "ts": "trading_symbol",
+	"request_type": "request_type",
+}
+
+// IndexKeyMapping — field names for index-level snapshots.
+var IndexKeyMapping = map[string]string{
+	"iv": "last_traded_price", "ic": "prev_day_close",
+	"tvalue": "timestamp", "highPrice": "high_price",
+	"lowPrice": "low_price", "openingPrice": "open",
+	"mul": "multiplier", "prec": "precision",
+	"cng": "change", "nc": "net_change_percentage",
+	"tk": "instrument_token", "e": "exchange_segment",
+}
+
+const (
+	OrderSource   = "NEOTRADEAPI"
+	QuotesChannel = 1
+)

--- a/client/go-client/neoapi/urls.go
+++ b/client/go-client/neoapi/urls.go
@@ -1,0 +1,65 @@
+package neoapi
+
+// WebSocket endpoints
+const (
+	WebSocketURL      = "wss://mlhsm.kotaksecurities.com"
+	OrderFeedURL      = "wss://mis.kotaksecurities.com/realtime"
+	OrderFeedURLADC   = "wss://cis.kotaksecurities.com/realtime"
+	OrderFeedURLE21   = "wss://e21.kotaksecurities.com/realtime"
+	OrderFeedURLE22   = "wss://e22.kotaksecurities.com/realtime"
+	OrderFeedURLE41   = "wss://e41.kotaksecurities.com/realtime"
+	OrderFeedURLE43   = "wss://e43.kotaksecurities.com/realtime"
+	BaseURL           = "https://mis.kotaksecurities.com"
+)
+
+// REST base URLs
+const (
+	UATBaseURL            = "https://nsbxapi-gw.kotaksecurities.com/"
+	ProdBaseURL           = "https://mnapi.kotaksecurities.com/"
+	ProdBaseURLADC        = "https://cnapi.kotaksecurities.com/"
+	ProdBaseURLNAPI       = "https://napi.kotaksecurities.com/"
+	ProdBaseURLGWNAPI     = "https://gw-napi.kotaksecurities.com/"
+	SessionUATBaseURL     = "https://nsbxapi.kotaksecurities.com/"
+	SessionProdBaseURL    = "https://mnapi.kotaksecurities.com/"
+	SessionProdBaseURLADC = "https://cnapi.kotaksecurities.com/"
+)
+
+// UATPaths — endpoint paths for UAT environment
+var UATPaths = map[string]string{
+	"totp_login":        "api/1.0/login/v6/totp/login",
+	"totp_validate":     "api/1.0/login/v6/totp/validate",
+	"place_order":       "orderapi/1.0/quick/order/rule/ms/place",
+	"cancel_order":      "orderapi/1.0/quick/order/cancel",
+	"modify_order":      "orderapi/1.0/quick/order/vr/modify",
+	"order_history":     "orderapi/1.0/quick/order/history",
+	"order_book":        "orderapi/1.0/quick/user/orders",
+	"trade_report":      "orderapi/1.0/quick/user/trades",
+	"positions":         "orderapi/1.0/quick/user/positions",
+	"holdings":          "portfolio/1.0/portfolio/v1/holdings",
+	"margin":            "orderapi/1.0/quick/user/check-margin",
+	"scrip_master":      "scrip/1.0/masterscrip/file-paths",
+	"limits":            "orderapi/1.0/quick/user/limits",
+	"logout":            "api/1.0/logout",
+	"quotes_neo_symbol": "script-details/1.0/quotes/neosymbol/{neo_symbols}/{quote_type}",
+}
+
+// ProdPaths — endpoint paths for PROD environment
+var ProdPaths = map[string]string{
+	"totp_login":           "login/1.0/tradeApiLogin",
+	"totp_validate":        "login/1.0/tradeApiValidate",
+	"place_order":          "quick/order/rule/ms/place",
+	"cancel_order":         "quick/order/cancel",
+	"cancel_cover_order":   "quick/order/co/exit",
+	"cancel_bracket_order": "quick/order/bo/exit",
+	"modify_order":         "quick/order/vr/modify",
+	"order_history":        "quick/order/history",
+	"order_book":           "quick/user/orders",
+	"trade_report":         "quick/user/trades",
+	"positions":            "quick/user/positions",
+	"holdings":             "portfolio/v1/holdings",
+	"margin":               "quick/user/check-margin",
+	"scrip_master":         "script-details/1.0/masterscrip/file-paths",
+	"limits":               "quick/user/limits",
+	"logout":               "apim/login/2.0/logout",
+	"quotes_neo_symbol":    "/script-details/1.0/quotes/neosymbol/{neo_symbols}/{quote_type}",
+}

--- a/client/go-client/neoapi/validation.go
+++ b/client/go-client/neoapi/validation.go
@@ -8,6 +8,12 @@ import (
 // Response is the loose response type — mirrors Python dict.
 type Response map[string]any
 
+var (
+	validityValues = []string{"DAY", "IOC"}
+	placeOrderTT   = []string{"B", "S", "Buy", "Sell"}
+	marginTT       = []string{"B", "S", "Buy", "Sell", "sell", "buy"}
+)
+
 func nonEmpty(val, name string) error {
 	if strings.TrimSpace(val) == "" {
 		return &APIValueError{Msg: fmt.Sprintf("%s is mandatory", name)}
@@ -35,9 +41,11 @@ func ValidatePlaceOrder(exchangeSegment, product, price, orderType, quantity, va
 	if _, ok := OrderType[orderType]; !ok {
 		return &APIValueError{Msg: "invalid order_type: " + orderType}
 	}
-	tt := strings.ToUpper(transactionType)
-	if tt != "B" && tt != "S" && tt != "BUY" && tt != "SELL" {
-		return &APIValueError{Msg: "transaction_type must be B/S"}
+	if !contains(validityValues, validity) {
+		return &APIValueError{Msg: "Invalid validity. Allowed values are DAY, IOC."}
+	}
+	if !contains(placeOrderTT, transactionType) {
+		return &APIValueError{Msg: "Invalid transaction type. Allowed values are B or Buy, S or Sell."}
 	}
 	return nil
 }
@@ -52,7 +60,7 @@ func ValidateOrderHistory(orderID string) error {
 	return nonEmpty(orderID, "order_id")
 }
 
-// ValidateMargin — basic field presence check.
+// ValidateMargin — mirrors req_data_validation.margin_validation allow-lists.
 func ValidateMargin(exchangeSegment, price, orderType, product, quantity, instrumentToken, transactionType string) error {
 	for k, v := range map[string]string{
 		"exchange_segment": exchangeSegment, "price": price, "order_type": orderType,
@@ -65,6 +73,15 @@ func ValidateMargin(exchangeSegment, price, orderType, product, quantity, instru
 	}
 	if _, ok := ExchangeSegment[exchangeSegment]; !ok {
 		return &APIValueError{Msg: "invalid exchange_segment: " + exchangeSegment}
+	}
+	if _, ok := Product[product]; !ok {
+		return &APIValueError{Msg: "invalid product: " + product}
+	}
+	if _, ok := OrderType[orderType]; !ok {
+		return &APIValueError{Msg: "invalid order_type: " + orderType}
+	}
+	if !contains(marginTT, transactionType) {
+		return &APIValueError{Msg: "Invalid transaction type. Allowed values are B or Buy, S or Sell."}
 	}
 	return nil
 }

--- a/client/go-client/neoapi/validation.go
+++ b/client/go-client/neoapi/validation.go
@@ -1,0 +1,93 @@
+package neoapi
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Response is the loose response type — mirrors Python dict.
+type Response map[string]any
+
+func nonEmpty(val, name string) error {
+	if strings.TrimSpace(val) == "" {
+		return &APIValueError{Msg: fmt.Sprintf("%s is mandatory", name)}
+	}
+	return nil
+}
+
+// ValidatePlaceOrder mirrors req_data_validation.place_order_validation.
+func ValidatePlaceOrder(exchangeSegment, product, price, orderType, quantity, validity, tradingSymbol, transactionType string) error {
+	for k, v := range map[string]string{
+		"exchange_segment": exchangeSegment, "product": product, "price": price,
+		"order_type": orderType, "quantity": quantity, "validity": validity,
+		"trading_symbol": tradingSymbol, "transaction_type": transactionType,
+	} {
+		if err := nonEmpty(v, k); err != nil {
+			return err
+		}
+	}
+	if _, ok := ExchangeSegment[exchangeSegment]; !ok {
+		return &APIValueError{Msg: "invalid exchange_segment: " + exchangeSegment}
+	}
+	if _, ok := Product[product]; !ok {
+		return &APIValueError{Msg: "invalid product: " + product}
+	}
+	if _, ok := OrderType[orderType]; !ok {
+		return &APIValueError{Msg: "invalid order_type: " + orderType}
+	}
+	tt := strings.ToUpper(transactionType)
+	if tt != "B" && tt != "S" && tt != "BUY" && tt != "SELL" {
+		return &APIValueError{Msg: "transaction_type must be B/S"}
+	}
+	return nil
+}
+
+// ValidateCancelOrder — order_id must be non-empty.
+func ValidateCancelOrder(orderID string) error {
+	return nonEmpty(orderID, "order_id")
+}
+
+// ValidateOrderHistory — order_id must be non-empty.
+func ValidateOrderHistory(orderID string) error {
+	return nonEmpty(orderID, "order_id")
+}
+
+// ValidateMargin — basic field presence check.
+func ValidateMargin(exchangeSegment, price, orderType, product, quantity, instrumentToken, transactionType string) error {
+	for k, v := range map[string]string{
+		"exchange_segment": exchangeSegment, "price": price, "order_type": orderType,
+		"product": product, "quantity": quantity, "instrument_token": instrumentToken,
+		"transaction_type": transactionType,
+	} {
+		if err := nonEmpty(v, k); err != nil {
+			return err
+		}
+	}
+	if _, ok := ExchangeSegment[exchangeSegment]; !ok {
+		return &APIValueError{Msg: "invalid exchange_segment: " + exchangeSegment}
+	}
+	return nil
+}
+
+// ValidateLimits — segment/exchange/product against allow-lists.
+func ValidateLimits(segment, exchange, product string) error {
+	if !contains(SegmentLimits, segment) {
+		return &APIValueError{Msg: "invalid segment: " + segment}
+	}
+	if !contains(ExchangeLimits, exchange) {
+		return &APIValueError{Msg: "invalid exchange: " + exchange}
+	}
+	if !contains(ProductLimits, product) {
+		return &APIValueError{Msg: "invalid product: " + product}
+	}
+	return nil
+}
+
+func contains(list []string, v string) bool {
+	for _, s := range list {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}

--- a/client/go-client/neoapi/websocket.go
+++ b/client/go-client/neoapi/websocket.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -17,6 +18,10 @@ type Instrument struct {
 
 // NeoWebSocket manages the two streaming connections (market data + order feed).
 // It mirrors the public shape of the Python NeoWebSocket class.
+//
+// marketOpen / orderOpen are accessed from multiple goroutines (read loops,
+// heartbeat tickers, external callers) so they must go through atomic.Bool
+// to keep the race detector happy.
 type NeoWebSocket struct {
 	sid         string
 	token       string
@@ -24,8 +29,8 @@ type NeoWebSocket struct {
 	dataCenter  string
 	marketConn  *websocket.Conn
 	orderConn   *websocket.Conn
-	marketOpen  bool
-	orderOpen   bool
+	marketOpen  atomic.Bool
+	orderOpen   atomic.Bool
 	subList     []Instrument
 	quotesIndex bool
 
@@ -57,7 +62,7 @@ func (w *NeoWebSocket) GetLiveFeed(instruments []Instrument, isIndex, isDepth bo
 	w.subList = append(w.subList, instruments...)
 	w.mu.Unlock()
 
-	if !w.marketOpen {
+	if !w.marketOpen.Load() {
 		if err := w.openMarketConn(); err != nil {
 			return err
 		}
@@ -87,7 +92,7 @@ func (w *NeoWebSocket) UnsubscribeList(instruments []Instrument, isIndex, isDept
 
 // GetOrderFeed opens the order-feed socket.
 func (w *NeoWebSocket) GetOrderFeed() error {
-	if w.orderOpen {
+	if w.orderOpen.Load() {
 		return nil
 	}
 	return w.openOrderConn()
@@ -99,7 +104,7 @@ func (w *NeoWebSocket) openMarketConn() error {
 		return err
 	}
 	w.marketConn = conn
-	w.marketOpen = true
+	w.marketOpen.Store(true)
 
 	handshake := map[string]any{"type": "cn", "Authorization": w.token, "Sid": w.sid}
 	if err := w.sendMarket(handshake); err != nil {
@@ -132,7 +137,7 @@ func (w *NeoWebSocket) openOrderConn() error {
 		return err
 	}
 	w.orderConn = conn
-	w.orderOpen = true
+	w.orderOpen.Store(true)
 
 	handshake := map[string]any{
 		"type": "CONNECTION", "Authorization": w.token, "Sid": w.sid, "source": "WEB",
@@ -160,10 +165,10 @@ func (w *NeoWebSocket) sendMarket(payload map[string]any) error {
 }
 
 func (w *NeoWebSocket) readMarket() {
-	for w.marketOpen {
+	for w.marketOpen.Load() {
 		_, msg, err := w.marketConn.ReadMessage()
 		if err != nil {
-			w.marketOpen = false
+			w.marketOpen.Store(false)
 			if w.OnError != nil {
 				w.OnError(err)
 			}
@@ -188,10 +193,10 @@ func (w *NeoWebSocket) readMarket() {
 }
 
 func (w *NeoWebSocket) readOrder() {
-	for w.orderOpen {
+	for w.orderOpen.Load() {
 		_, msg, err := w.orderConn.ReadMessage()
 		if err != nil {
-			w.orderOpen = false
+			w.orderOpen.Store(false)
 			if w.OnError != nil {
 				w.OnError(err)
 			}
@@ -212,7 +217,7 @@ func (w *NeoWebSocket) marketHeartbeat() {
 	ticker := time.NewTicker(29 * time.Second)
 	defer ticker.Stop()
 	for range ticker.C {
-		if !w.marketOpen {
+		if !w.marketOpen.Load() {
 			return
 		}
 		_ = w.sendMarket(map[string]any{"type": "hb"})
@@ -223,7 +228,7 @@ func (w *NeoWebSocket) orderHeartbeat() {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 	for range ticker.C {
-		if !w.orderOpen {
+		if !w.orderOpen.Load() {
 			return
 		}
 		buf, _ := json.Marshal(map[string]any{"type": "HB"})
@@ -235,11 +240,11 @@ func (w *NeoWebSocket) orderHeartbeat() {
 func (w *NeoWebSocket) Close() {
 	if w.marketConn != nil {
 		_ = w.marketConn.Close()
-		w.marketOpen = false
+		w.marketOpen.Store(false)
 	}
 	if w.orderConn != nil {
 		_ = w.orderConn.Close()
-		w.orderOpen = false
+		w.orderOpen.Store(false)
 	}
 }
 

--- a/client/go-client/neoapi/websocket.go
+++ b/client/go-client/neoapi/websocket.go
@@ -1,0 +1,310 @@
+package neoapi
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Instrument is a single subscription target.
+type Instrument struct {
+	InstrumentToken string `json:"instrument_token"`
+	ExchangeSegment string `json:"exchange_segment"`
+}
+
+// NeoWebSocket manages the two streaming connections (market data + order feed).
+// It mirrors the public shape of the Python NeoWebSocket class.
+type NeoWebSocket struct {
+	sid         string
+	token       string
+	serverID    string
+	dataCenter  string
+	marketConn  *websocket.Conn
+	orderConn   *websocket.Conn
+	marketOpen  bool
+	orderOpen   bool
+	subList     []Instrument
+	quotesIndex bool
+
+	OnOpen    func()
+	OnMessage func(msg any)
+	OnError   func(err error)
+	OnClose   func()
+
+	mu sync.Mutex
+}
+
+// NewNeoWebSocket constructs a socket. Callbacks are wired later by the parent Client.
+func NewNeoWebSocket(sid, token, serverID, dataCenter string) *NeoWebSocket {
+	return &NeoWebSocket{sid: sid, token: token, serverID: serverID, dataCenter: dataCenter}
+}
+
+// GetLiveFeed subscribes to the given instruments. Opens the socket lazily.
+func (w *NeoWebSocket) GetLiveFeed(instruments []Instrument, isIndex, isDepth bool) error {
+	subType := ReqTypeValues["SCRIP_SUBS"]
+	if isIndex {
+		subType = ReqTypeValues["INDEX_SUBS"]
+		w.quotesIndex = true
+	}
+	if isDepth {
+		subType = ReqTypeValues["DEPTH_SUBS"]
+	}
+
+	w.mu.Lock()
+	w.subList = append(w.subList, instruments...)
+	w.mu.Unlock()
+
+	if !w.marketOpen {
+		if err := w.openMarketConn(); err != nil {
+			return err
+		}
+	}
+
+	scrips := formatScrips(instruments)
+	payload := map[string]any{"type": subType, "scrips": scrips, "channelnum": 2}
+	return w.sendMarket(payload)
+}
+
+// UnsubscribeList stops streaming the given instruments.
+func (w *NeoWebSocket) UnsubscribeList(instruments []Instrument, isIndex, isDepth bool) error {
+	unsubType := ReqTypeValues["SCRIP_UNSUBS"]
+	if isIndex {
+		unsubType = ReqTypeValues["INDEX_UNSUBS"]
+	}
+	if isDepth {
+		unsubType = ReqTypeValues["DEPTH_UNSUBS"]
+	}
+	if w.marketConn == nil {
+		return &APIValueError{Msg: "Socket Connection has been closed"}
+	}
+	scrips := formatScrips(instruments)
+	payload := map[string]any{"type": unsubType, "scrips": scrips, "channelnum": 2}
+	return w.sendMarket(payload)
+}
+
+// GetOrderFeed opens the order-feed socket.
+func (w *NeoWebSocket) GetOrderFeed() error {
+	if w.orderOpen {
+		return nil
+	}
+	return w.openOrderConn()
+}
+
+func (w *NeoWebSocket) openMarketConn() error {
+	conn, _, err := websocket.DefaultDialer.Dial(WebSocketURL, nil)
+	if err != nil {
+		return err
+	}
+	w.marketConn = conn
+	w.marketOpen = true
+
+	handshake := map[string]any{"type": "cn", "Authorization": w.token, "Sid": w.sid}
+	if err := w.sendMarket(handshake); err != nil {
+		return err
+	}
+	if w.OnOpen != nil {
+		w.OnOpen()
+	}
+	go w.readMarket()
+	go w.marketHeartbeat()
+	return nil
+}
+
+func (w *NeoWebSocket) openOrderConn() error {
+	url := OrderFeedURL
+	switch strings.ToLower(w.dataCenter) {
+	case "adc":
+		url = OrderFeedURLADC
+	case "e21":
+		url = OrderFeedURLE21
+	case "e22":
+		url = OrderFeedURLE22
+	case "e41":
+		url = OrderFeedURLE41
+	case "e43":
+		url = OrderFeedURLE43
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		return err
+	}
+	w.orderConn = conn
+	w.orderOpen = true
+
+	handshake := map[string]any{
+		"type": "CONNECTION", "Authorization": w.token, "Sid": w.sid, "source": "WEB",
+	}
+	buf, _ := json.Marshal(handshake)
+	if err := w.orderConn.WriteMessage(websocket.TextMessage, buf); err != nil {
+		return err
+	}
+	if w.OnOpen != nil {
+		w.OnOpen()
+	}
+	go w.readOrder()
+	go w.orderHeartbeat()
+	return nil
+}
+
+func (w *NeoWebSocket) sendMarket(payload map[string]any) error {
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.marketConn.WriteMessage(websocket.TextMessage, buf)
+}
+
+func (w *NeoWebSocket) readMarket() {
+	for w.marketOpen {
+		_, msg, err := w.marketConn.ReadMessage()
+		if err != nil {
+			w.marketOpen = false
+			if w.OnError != nil {
+				w.OnError(err)
+			}
+			if w.OnClose != nil {
+				w.OnClose()
+			}
+			return
+		}
+		var anyMsg any
+		if err := json.Unmarshal(msg, &anyMsg); err == nil {
+			if w.OnMessage != nil {
+				w.OnMessage(map[string]any{"type": "stock_feed", "data": anyMsg})
+			}
+		} else {
+			// Raw binary packet — hand it to the codec.
+			decoded, err := DecodeBinaryFrame(msg)
+			if err == nil && w.OnMessage != nil {
+				w.OnMessage(map[string]any{"type": "stock_feed", "data": decoded})
+			}
+		}
+	}
+}
+
+func (w *NeoWebSocket) readOrder() {
+	for w.orderOpen {
+		_, msg, err := w.orderConn.ReadMessage()
+		if err != nil {
+			w.orderOpen = false
+			if w.OnError != nil {
+				w.OnError(err)
+			}
+			if w.OnClose != nil {
+				w.OnClose()
+			}
+			return
+		}
+		var anyMsg any
+		_ = json.Unmarshal(msg, &anyMsg)
+		if w.OnMessage != nil {
+			w.OnMessage(map[string]any{"type": "order_feed", "data": anyMsg})
+		}
+	}
+}
+
+func (w *NeoWebSocket) marketHeartbeat() {
+	ticker := time.NewTicker(29 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		if !w.marketOpen {
+			return
+		}
+		_ = w.sendMarket(map[string]any{"type": "hb"})
+	}
+}
+
+func (w *NeoWebSocket) orderHeartbeat() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		if !w.orderOpen {
+			return
+		}
+		buf, _ := json.Marshal(map[string]any{"type": "HB"})
+		_ = w.orderConn.WriteMessage(websocket.TextMessage, buf)
+	}
+}
+
+// Close shuts down both sockets.
+func (w *NeoWebSocket) Close() {
+	if w.marketConn != nil {
+		_ = w.marketConn.Close()
+		w.marketOpen = false
+	}
+	if w.orderConn != nil {
+		_ = w.orderConn.Close()
+		w.orderOpen = false
+	}
+}
+
+func formatScrips(instruments []Instrument) string {
+	parts := make([]string, 0, len(instruments))
+	for _, i := range instruments {
+		parts = append(parts, i.ExchangeSegment+"|"+i.InstrumentToken)
+	}
+	return strings.Join(parts, "&")
+}
+
+// Subscribe bridges the Client API to the underlying socket.
+func (c *Client) Subscribe(instruments []Instrument, isIndex, isDepth bool) error {
+	if err := c.requireLogin(); err != nil {
+		return err
+	}
+	if c.ws == nil {
+		c.ws = NewNeoWebSocket(c.Config.EditSID, c.Config.EditToken, c.Config.ServerID, c.Config.DataCenter)
+		c.wireWS()
+	}
+	return c.ws.GetLiveFeed(instruments, isIndex, isDepth)
+}
+
+// Unsubscribe removes instruments from the live feed.
+func (c *Client) Unsubscribe(instruments []Instrument, isIndex, isDepth bool) error {
+	if err := c.requireLogin(); err != nil {
+		return err
+	}
+	if c.ws == nil {
+		return &APIValueError{Msg: "no active subscription"}
+	}
+	return c.ws.UnsubscribeList(instruments, isIndex, isDepth)
+}
+
+// SubscribeToOrderFeed starts streaming order/trade updates.
+func (c *Client) SubscribeToOrderFeed() error {
+	if err := c.requireLogin(); err != nil {
+		return err
+	}
+	if c.ws == nil {
+		c.ws = NewNeoWebSocket(c.Config.EditSID, c.Config.EditToken, c.Config.ServerID, c.Config.DataCenter)
+		c.wireWS()
+	}
+	return c.ws.GetOrderFeed()
+}
+
+func (c *Client) wireWS() {
+	c.ws.OnOpen = func() {
+		if c.OnOpen != nil {
+			c.OnOpen("The Session has been Opened!")
+		}
+	}
+	c.ws.OnMessage = func(msg any) {
+		if c.OnMessage != nil {
+			c.OnMessage(msg)
+		}
+	}
+	c.ws.OnError = func(err error) {
+		if c.OnError != nil {
+			c.OnError(err)
+		}
+	}
+	c.ws.OnClose = func() {
+		if c.OnClose != nil {
+			c.OnClose("The Session has been Closed!")
+		}
+	}
+}

--- a/client/java-client/README.md
+++ b/client/java-client/README.md
@@ -1,0 +1,66 @@
+# Kotak Neo — Java client
+
+Java 17+ port of the Python `neo_api_client`.
+
+## Install
+
+```bash
+cd client/java-client
+mvn -q compile
+```
+
+## Quickstart
+
+```java
+import com.kotak.neo.client.NeoAPI;
+import com.kotak.neo.client.api.OrderApi;
+
+NeoAPI client = new NeoAPI("prod", null, null, "YOUR_CONSUMER_KEY");
+
+client.totpLogin("+919999999999", "ABC12", "123456");
+client.totpValidate("1234");
+
+OrderApi.PlaceOrderRequest req = new OrderApi.PlaceOrderRequest();
+req.exchangeSegment = "nse_cm";
+req.product = "MIS";
+req.price = "100.50";
+req.orderType = "L";
+req.quantity = "1";
+req.validity = "DAY";
+req.tradingSymbol = "RELIANCE-EQ";
+req.transactionType = "B";
+System.out.println(client.placeOrder(req));
+```
+
+## Streaming
+
+```java
+client.onMessage = m -> System.out.println(m);
+client.subscribe(
+    java.util.List.of(new com.kotak.neo.client.websocket.Instrument("11536", "nse_cm")),
+    false, false);
+```
+
+## Method map (Python → Java)
+
+| Python | Java |
+|---|---|
+| `totp_login` / `totp_validate` / `logout` | `totpLogin` / `totpValidate` / `logout` |
+| `place_order` / `modify_order` | `placeOrder` / `modifyOrder` |
+| `cancel_order` etc. | `cancelOrder` / `cancelCoverOrder` / `cancelBracketOrder` |
+| `order_report` / `order_history` / `trade_report` | `orderReport` / `orderHistory` / `tradeReport` |
+| `positions` / `holdings` / `limits` | `positions` / `holdings` / `limits` |
+| `margin_required` | `marginRequired` |
+| `scrip_master` / `search_scrip` | `scripMaster` / `searchScrip` |
+| `quotes` | `quotes` |
+| `subscribe` / `un_subscribe` | `subscribe` / `unSubscribe` |
+| `subscribe_to_orderfeed` | `subscribeToOrderFeed` |
+
+## Run the demo
+
+```bash
+NEO_ENV=prod \
+NEO_CONSUMER=BASE64_CONSUMER \
+NEO_MOBILE=+919999999999 NEO_UCC=ABC12 NEO_TOTP=123456 NEO_MPIN=1234 \
+mvn -q exec:java -Dexec.mainClass=com.kotak.neo.client.Demo
+```

--- a/client/java-client/pom.xml
+++ b/client/java-client/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.kotak.neo</groupId>
+    <artifactId>neo-client</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Kotak Neo Java Client</name>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
+            <version>1.5.4</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <mainClass>com.kotak.neo.client.Demo</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/client/java-client/src/main/java/com/kotak/neo/client/Configuration.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/Configuration.java
@@ -1,0 +1,72 @@
+package com.kotak.neo.client;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.kotak.neo.client.exceptions.ApiKeyError;
+import com.kotak.neo.client.exceptions.ApiValueError;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class Configuration {
+    public String host;
+    public String bearerToken;
+    public String viewToken;
+    public String sid;
+    public String userId;
+    public String editToken;
+    public String editSid;
+    public String editRid;
+    public String serverId;
+    public String neoFinKey;
+    public String dataCenter;
+    public String baseUrl;
+    public String consumerKey;
+
+    public Configuration(String environment) {
+        this.host = environment == null ? "uat" : environment;
+    }
+
+    public boolean isLoggedIn() {
+        return editToken != null && !editToken.isEmpty() && editSid != null && !editSid.isEmpty();
+    }
+
+    public String getDomain(boolean sessionInit) {
+        String h = host.trim().toLowerCase();
+        if (!h.equals("prod") && !h.equals("uat")) {
+            throw new ApiValueError("environment must be 'prod' or 'uat'");
+        }
+        if (sessionInit) return Urls.BASE_URL;
+        if (h.equals("prod")) return (baseUrl != null && !baseUrl.isEmpty()) ? baseUrl : Urls.PROD_BASE_URL;
+        return Urls.UAT_BASE_URL;
+    }
+
+    public String getUrl(String apiInfo) {
+        String h = host.trim().toLowerCase();
+        String domain = getDomain(false);
+        if (domain.endsWith("/")) domain = domain.substring(0, domain.length() - 1);
+        String path = h.equals("prod") ? Urls.PROD_PATHS.get(apiInfo) : Urls.UAT_PATHS.get(apiInfo);
+        if (path == null) throw new ApiValueError("unknown endpoint: " + apiInfo);
+        return domain + "/" + path;
+    }
+
+    public String getNeoFinKey() {
+        if (neoFinKey != null && !neoFinKey.isEmpty()) return neoFinKey;
+        return host.trim().equalsIgnoreCase("prod")
+                ? "neotradeapi"
+                : "bQJNkL5z8m4aGcRgjDvXhHfSx7VpZnE";
+    }
+
+    public String extractUserId(String viewToken) {
+        if (viewToken == null || viewToken.isEmpty()) {
+            throw new ApiValueError("view_token is empty — call totpLogin first");
+        }
+        String[] parts = viewToken.split("\\.");
+        if (parts.length < 2) throw new ApiValueError("invalid JWT");
+        byte[] payload = Base64.getUrlDecoder().decode(parts[1]);
+        JsonObject claims = JsonParser.parseString(new String(payload, StandardCharsets.UTF_8)).getAsJsonObject();
+        if (!claims.has("sub")) throw new ApiKeyError("sub claim missing from token");
+        this.userId = claims.get("sub").getAsString();
+        return this.userId;
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/Demo.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/Demo.java
@@ -1,0 +1,29 @@
+package com.kotak.neo.client;
+
+public class Demo {
+    public static void main(String[] args) {
+        String env = System.getenv().getOrDefault("NEO_ENV", "uat");
+        String consumer = System.getenv().getOrDefault("NEO_CONSUMER", "");
+        String mobile = System.getenv("NEO_MOBILE");
+        String ucc = System.getenv("NEO_UCC");
+        String totp = System.getenv("NEO_TOTP");
+        String mpin = System.getenv("NEO_MPIN");
+
+        NeoAPI client = new NeoAPI(env, null, null, consumer);
+
+        client.onOpen = m -> System.out.println("[ws] open : " + m);
+        client.onMessage = m -> System.out.println("[ws] msg  : " + m);
+        client.onError = e -> System.out.println("[ws] err  : " + e.getMessage());
+        client.onClose = m -> System.out.println("[ws] close: " + m);
+
+        if (mobile == null || ucc == null || totp == null || mpin == null) {
+            System.out.println("Set NEO_MOBILE, NEO_UCC, NEO_TOTP, NEO_MPIN to exercise login.");
+            System.out.println("Client constructed OK; skipping live calls.");
+            return;
+        }
+
+        System.out.println("totp_login: " + client.totpLogin(mobile, ucc, totp));
+        System.out.println("totp_validate: " + client.totpValidate(mpin));
+        System.out.println("order_report: " + client.orderReport());
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/NeoAPI.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/NeoAPI.java
@@ -1,0 +1,162 @@
+package com.kotak.neo.client;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.kotak.neo.client.api.LoginApi;
+import com.kotak.neo.client.api.MarginApi;
+import com.kotak.neo.client.api.OrderApi;
+import com.kotak.neo.client.api.PortfolioApi;
+import com.kotak.neo.client.api.QuotesApi;
+import com.kotak.neo.client.api.ScripApi;
+import com.kotak.neo.client.rest.RestClient;
+import com.kotak.neo.client.websocket.Instrument;
+import com.kotak.neo.client.websocket.NeoWebSocket;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * NeoAPI — top-level SDK entry point. Mirrors the Python NeoAPI class.
+ */
+public class NeoAPI {
+    public final Configuration configuration;
+    private final RestClient rest;
+    private final LoginApi loginApi;
+    private final OrderApi orderApi;
+    private final PortfolioApi portfolioApi;
+    private final MarginApi marginApi;
+    private final ScripApi scripApi;
+    private final QuotesApi quotesApi;
+    private NeoWebSocket neoWebSocket;
+
+    public Consumer<String> onOpen;
+    public Consumer<Object> onMessage;
+    public Consumer<Throwable> onError;
+    public Consumer<String> onClose;
+
+    public NeoAPI() {
+        this("uat", null, null, null);
+    }
+
+    public NeoAPI(String environment, String accessToken, String neoFinKey, String consumerKey) {
+        this.configuration = new Configuration(environment);
+        this.configuration.bearerToken = accessToken;
+        this.configuration.neoFinKey = neoFinKey;
+        this.configuration.consumerKey = consumerKey;
+        this.rest = new RestClient(this.configuration);
+        this.loginApi = new LoginApi(rest, configuration);
+        this.orderApi = new OrderApi(rest, configuration);
+        this.portfolioApi = new PortfolioApi(rest, configuration);
+        this.marginApi = new MarginApi(rest, configuration);
+        this.scripApi = new ScripApi(rest, configuration);
+        this.quotesApi = new QuotesApi(rest, configuration);
+    }
+
+    private JsonObject notLoggedInError() {
+        JsonObject err = new JsonObject();
+        err.addProperty("Error Message", "Complete the 2fa process before accessing this application");
+        return err;
+    }
+
+    private JsonElement gated(java.util.function.Supplier<JsonElement> op) {
+        if (!configuration.isLoggedIn()) return notLoggedInError();
+        try { return op.get(); }
+        catch (Exception ex) {
+            JsonObject err = new JsonObject();
+            err.addProperty("Error", ex.getMessage() == null ? ex.toString() : ex.getMessage());
+            return err;
+        }
+    }
+
+    // ---------- Auth ----------
+    public JsonElement totpLogin(String mobileNumber, String ucc, String totp) {
+        return loginApi.totpLogin(mobileNumber, ucc, totp);
+    }
+    public JsonElement totpValidate(String mpin) { return loginApi.totpValidate(mpin); }
+
+    public JsonElement logout() {
+        if (!configuration.isLoggedIn()) return notLoggedInError();
+        configuration.bearerToken = null;
+        configuration.editSid = null;
+        configuration.editToken = null;
+        JsonObject ok = new JsonObject();
+        ok.addProperty("State", "OK");
+        ok.addProperty("message", "You have been successfully logged out");
+        return ok;
+    }
+
+    // ---------- Orders ----------
+    public JsonElement placeOrder(OrderApi.PlaceOrderRequest req) { return gated(() -> orderApi.placeOrder(req)); }
+    public JsonElement modifyOrder(OrderApi.ModifyOrderRequest req) { return gated(() -> orderApi.modifyOrder(req)); }
+    public JsonElement cancelOrder(String orderId, String amo, boolean verify) {
+        return gated(() -> orderApi.cancelOrder(orderId, amo == null ? "NO" : amo, verify));
+    }
+    public JsonElement cancelCoverOrder(String orderId, String amo, boolean verify) {
+        return gated(() -> orderApi.cancelCoverOrder(orderId, amo == null ? "NO" : amo, verify));
+    }
+    public JsonElement cancelBracketOrder(String orderId, String amo, boolean verify) {
+        return gated(() -> orderApi.cancelBracketOrder(orderId, amo == null ? "NO" : amo, verify));
+    }
+
+    // ---------- Reports ----------
+    public JsonElement orderReport() { return gated(orderApi::orderReport); }
+    public JsonElement orderHistory(String orderId) { return gated(() -> orderApi.orderHistory(orderId)); }
+    public JsonElement tradeReport(String orderId) { return gated(() -> orderApi.tradeReport(orderId)); }
+
+    // ---------- Portfolio ----------
+    public JsonElement positions() { return gated(portfolioApi::positions); }
+    public JsonElement holdings() { return gated(portfolioApi::holdings); }
+    public JsonElement limits(String segment, String exchange, String product) {
+        String s = segment == null ? "ALL" : segment;
+        String e = exchange == null ? "ALL" : exchange;
+        String p = product == null ? "ALL" : product;
+        return gated(() -> portfolioApi.limits(s, e, p));
+    }
+
+    // ---------- Pricing ----------
+    public JsonElement marginRequired(MarginApi.MarginRequiredRequest req) {
+        return gated(() -> marginApi.marginRequired(req));
+    }
+    public JsonElement quotes(List<Instrument> instruments, String quoteType) {
+        return quotesApi.quotes(instruments, quoteType);
+    }
+
+    // ---------- Scrip ----------
+    public JsonElement scripMaster(String exchangeSegment) { return gated(() -> scripApi.scripMaster(exchangeSegment)); }
+    public JsonElement searchScrip(String exchangeSegment, String symbol, String expiry,
+                                   String optionType, String strikePrice) {
+        return gated(() -> scripApi.searchScrip(exchangeSegment, symbol, expiry, optionType, strikePrice));
+    }
+
+    // ---------- Streaming ----------
+    public void subscribe(List<Instrument> instruments, boolean isIndex, boolean isDepth) {
+        if (!configuration.isLoggedIn()) { if (onError != null) onError.accept(new IllegalStateException("not logged in")); return; }
+        ensureSocket();
+        try { neoWebSocket.getLiveFeed(instruments, isIndex, isDepth); }
+        catch (Exception ex) { if (onError != null) onError.accept(ex); }
+    }
+
+    public void unSubscribe(List<Instrument> instruments, boolean isIndex, boolean isDepth) {
+        if (!configuration.isLoggedIn()) { if (onError != null) onError.accept(new IllegalStateException("not logged in")); return; }
+        ensureSocket();
+        neoWebSocket.unSubscribeList(instruments, isIndex, isDepth);
+    }
+
+    public void subscribeToOrderFeed() {
+        if (!configuration.isLoggedIn()) { if (onError != null) onError.accept(new IllegalStateException("not logged in")); return; }
+        ensureSocket();
+        try { neoWebSocket.getOrderFeed(); }
+        catch (Exception ex) { if (onError != null) onError.accept(ex); }
+    }
+
+    private void ensureSocket() {
+        if (neoWebSocket != null) return;
+        neoWebSocket = new NeoWebSocket(
+                configuration.editSid, configuration.editToken,
+                configuration.serverId, configuration.dataCenter);
+        neoWebSocket.onOpen = m -> { if (onOpen != null) onOpen.accept(m); };
+        neoWebSocket.onMessage = m -> { if (onMessage != null) onMessage.accept(m); };
+        neoWebSocket.onError = e -> { if (onError != null) onError.accept(e); };
+        neoWebSocket.onClose = m -> { if (onClose != null) onClose.accept(m); };
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/Settings.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/Settings.java
@@ -1,0 +1,58 @@
+package com.kotak.neo.client;
+
+import java.util.Map;
+import java.util.Set;
+
+public final class Settings {
+    public static final Map<String, String> EXCHANGE_SEGMENT = Map.ofEntries(
+            Map.entry("nse_cm", "nse_cm"), Map.entry("NSE", "nse_cm"), Map.entry("nse", "nse_cm"),
+            Map.entry("BSE", "bse_cm"), Map.entry("bse", "bse_cm"), Map.entry("bse_cm", "bse_cm"),
+            Map.entry("NFO", "nse_fo"), Map.entry("nse_fo", "nse_fo"), Map.entry("nfo", "nse_fo"),
+            Map.entry("BFO", "bse_fo"), Map.entry("bse_fo", "bse_fo"), Map.entry("bfo", "bse_fo"),
+            Map.entry("CDS", "cde_fo"), Map.entry("cde_fo", "cde_fo"), Map.entry("cds", "cde_fo"),
+            Map.entry("BCD", "bcs-fo"), Map.entry("bcs-fo", "bcs-fo"), Map.entry("bcd", "bcs-fo"),
+            Map.entry("MCX", "mcx_fo"), Map.entry("mcx", "mcx_fo"), Map.entry("mcx_fo", "mcx_fo")
+    );
+
+    public static final Map<String, String> PRODUCT = Map.ofEntries(
+            Map.entry("Normal", "NRML"), Map.entry("NRML", "NRML"),
+            Map.entry("CNC", "CNC"), Map.entry("cnc", "CNC"), Map.entry("Cash and Carry", "CNC"),
+            Map.entry("MIS", "MIS"), Map.entry("mis", "MIS"),
+            Map.entry("INTRADAY", "INTRADAY"), Map.entry("intraday", "INTRADAY"),
+            Map.entry("Cover Order", "CO"), Map.entry("co", "CO"), Map.entry("CO", "CO"),
+            Map.entry("BO", "BO"), Map.entry("Bracket Order", "BO"), Map.entry("bo", "BO"),
+            Map.entry("mtf", "MTF"), Map.entry("MTF", "MTF")
+    );
+
+    public static final Map<String, String> ORDER_TYPE = Map.ofEntries(
+            Map.entry("Limit", "L"), Map.entry("L", "L"), Map.entry("l", "L"),
+            Map.entry("MKT", "MKT"), Map.entry("mkt", "MKT"), Map.entry("Market", "MKT"),
+            Map.entry("sl", "SL"), Map.entry("SL", "SL"), Map.entry("Stop loss limit", "SL"),
+            Map.entry("Stop loss market", "SL-M"), Map.entry("SL-M", "SL-M"), Map.entry("sl-m", "SL-M"),
+            Map.entry("Spread", "SP"), Map.entry("SP", "SP"), Map.entry("sp", "SP"),
+            Map.entry("2L", "2L"), Map.entry("2l", "2L"), Map.entry("Two Leg", "2L"),
+            Map.entry("3L", "3L"), Map.entry("3l", "3L"), Map.entry("Three leg", "3L")
+    );
+
+    public static final Set<String> SEGMENT_LIMITS = Set.of("CASH", "CUR", "FO", "ALL");
+    public static final Set<String> EXCHANGE_LIMITS = Set.of("NSE", "BSE", "ALL");
+    public static final Set<String> PRODUCT_LIMITS = Set.of("CNC", "MIS", "NRML", "ALL");
+
+    public static final Map<String, String> REQ_TYPE_VALUES = Map.ofEntries(
+            Map.entry("CONNECTION", "cn"),
+            Map.entry("SCRIP_SUBS", "mws"),
+            Map.entry("SCRIP_UNSUBS", "mwu"),
+            Map.entry("INDEX_SUBS", "ifs"),
+            Map.entry("INDEX_UNSUBS", "ifu"),
+            Map.entry("DEPTH_SUBS", "dps"),
+            Map.entry("DEPTH_UNSUBS", "dpu"),
+            Map.entry("SNAP_MW", "mwsp"),
+            Map.entry("SNAP_DP", "dpsp"),
+            Map.entry("SNAP_IF", "ifsp")
+    );
+
+    public static final String ORDER_SOURCE = "NEOTRADEAPI";
+    public static final int QUOTES_CHANNEL = 1;
+
+    private Settings() {}
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/Urls.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/Urls.java
@@ -1,0 +1,58 @@
+package com.kotak.neo.client;
+
+import java.util.Map;
+
+public final class Urls {
+    public static final String WEBSOCKET_URL = "wss://mlhsm.kotaksecurities.com";
+    public static final String ORDER_FEED_URL = "wss://mis.kotaksecurities.com/realtime";
+    public static final String ORDER_FEED_URL_ADC = "wss://cis.kotaksecurities.com/realtime";
+    public static final String ORDER_FEED_URL_E21 = "wss://e21.kotaksecurities.com/realtime";
+    public static final String ORDER_FEED_URL_E22 = "wss://e22.kotaksecurities.com/realtime";
+    public static final String ORDER_FEED_URL_E41 = "wss://e41.kotaksecurities.com/realtime";
+    public static final String ORDER_FEED_URL_E43 = "wss://e43.kotaksecurities.com/realtime";
+
+    public static final String BASE_URL = "https://mis.kotaksecurities.com";
+
+    public static final String UAT_BASE_URL = "https://nsbxapi-gw.kotaksecurities.com/";
+    public static final String PROD_BASE_URL = "https://mnapi.kotaksecurities.com/";
+
+    public static final Map<String, String> UAT_PATHS = Map.ofEntries(
+            Map.entry("totp_login", "api/1.0/login/v6/totp/login"),
+            Map.entry("totp_validate", "api/1.0/login/v6/totp/validate"),
+            Map.entry("place_order", "orderapi/1.0/quick/order/rule/ms/place"),
+            Map.entry("cancel_order", "orderapi/1.0/quick/order/cancel"),
+            Map.entry("modify_order", "orderapi/1.0/quick/order/vr/modify"),
+            Map.entry("order_history", "orderapi/1.0/quick/order/history"),
+            Map.entry("order_book", "orderapi/1.0/quick/user/orders"),
+            Map.entry("trade_report", "orderapi/1.0/quick/user/trades"),
+            Map.entry("positions", "orderapi/1.0/quick/user/positions"),
+            Map.entry("holdings", "portfolio/1.0/portfolio/v1/holdings"),
+            Map.entry("margin", "orderapi/1.0/quick/user/check-margin"),
+            Map.entry("scrip_master", "scrip/1.0/masterscrip/file-paths"),
+            Map.entry("limits", "orderapi/1.0/quick/user/limits"),
+            Map.entry("logout", "api/1.0/logout"),
+            Map.entry("quotes_neo_symbol", "script-details/1.0/quotes/neosymbol/{neo_symbols}/{quote_type}")
+    );
+
+    public static final Map<String, String> PROD_PATHS = Map.ofEntries(
+            Map.entry("totp_login", "login/1.0/tradeApiLogin"),
+            Map.entry("totp_validate", "login/1.0/tradeApiValidate"),
+            Map.entry("place_order", "quick/order/rule/ms/place"),
+            Map.entry("cancel_order", "quick/order/cancel"),
+            Map.entry("cancel_cover_order", "quick/order/co/exit"),
+            Map.entry("cancel_bracket_order", "quick/order/bo/exit"),
+            Map.entry("modify_order", "quick/order/vr/modify"),
+            Map.entry("order_history", "quick/order/history"),
+            Map.entry("order_book", "quick/user/orders"),
+            Map.entry("trade_report", "quick/user/trades"),
+            Map.entry("positions", "quick/user/positions"),
+            Map.entry("holdings", "portfolio/v1/holdings"),
+            Map.entry("margin", "quick/user/check-margin"),
+            Map.entry("scrip_master", "script-details/1.0/masterscrip/file-paths"),
+            Map.entry("limits", "quick/user/limits"),
+            Map.entry("logout", "apim/login/2.0/logout"),
+            Map.entry("quotes_neo_symbol", "/script-details/1.0/quotes/neosymbol/{neo_symbols}/{quote_type}")
+    );
+
+    private Urls() {}
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/api/LoginApi.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/api/LoginApi.java
@@ -1,0 +1,99 @@
+package com.kotak.neo.client.api;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.kotak.neo.client.Configuration;
+import com.kotak.neo.client.Urls;
+import com.kotak.neo.client.rest.RestClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LoginApi {
+    private final RestClient rest;
+    private final Configuration config;
+
+    public LoginApi(RestClient rest, Configuration config) {
+        this.rest = rest;
+        this.config = config;
+    }
+
+    public JsonElement totpLogin(String mobileNumber, String ucc, String totp) {
+        if (mobileNumber == null || ucc == null || totp == null
+                || mobileNumber.isEmpty() || ucc.isEmpty() || totp.isEmpty()) {
+            JsonObject error = new JsonObject();
+            JsonObject msg = new JsonObject();
+            msg.addProperty("message", "mobile_number, ucc or totp missing");
+            com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+            arr.add(msg);
+            error.add("error", arr);
+            return error;
+        }
+
+        String host = config.host.trim().toLowerCase();
+        String path = host.equals("prod") ? Urls.PROD_PATHS.get("totp_login") : Urls.UAT_PATHS.get("totp_login");
+        String url = Urls.BASE_URL.replaceAll("/$", "") + "/" + path;
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", config.consumerKey == null ? "" : config.consumerKey);
+        headers.put("neo-fin-key", config.getNeoFinKey());
+        headers.put("Content-Type", "application/json");
+
+        Map<String, String> body = new HashMap<>();
+        body.put("mobileNumber", mobileNumber);
+        body.put("ucc", ucc);
+        body.put("totp", totp);
+
+        RestClient.Response r = rest.request("POST", url, null, headers, body);
+        if (r.status >= 200 && r.status <= 299 && r.data.isJsonObject()) {
+            JsonObject obj = r.data.getAsJsonObject();
+            if (obj.has("data") && obj.get("data").isJsonObject()) {
+                JsonObject data = obj.getAsJsonObject("data");
+                if (data.has("token")) config.viewToken = data.get("token").getAsString();
+                if (data.has("sid")) config.sid = data.get("sid").getAsString();
+            }
+        }
+        return r.data;
+    }
+
+    public JsonElement totpValidate(String mpin) {
+        if (mpin == null || mpin.isEmpty()) {
+            JsonObject error = new JsonObject();
+            JsonObject msg = new JsonObject();
+            msg.addProperty("message", "Mpin is missing");
+            com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+            arr.add(msg);
+            error.add("error", arr);
+            return error;
+        }
+
+        String host = config.host.trim().toLowerCase();
+        String path = host.equals("prod") ? Urls.PROD_PATHS.get("totp_validate") : Urls.UAT_PATHS.get("totp_validate");
+        String url = Urls.BASE_URL.replaceAll("/$", "") + "/" + path;
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", config.consumerKey == null ? "" : config.consumerKey);
+        headers.put("sid", config.sid == null ? "" : config.sid);
+        headers.put("Auth", config.viewToken == null ? "" : config.viewToken);
+        headers.put("neo-fin-key", config.getNeoFinKey());
+        headers.put("Content-Type", "application/json");
+
+        Map<String, String> body = new HashMap<>();
+        body.put("mpin", mpin);
+
+        RestClient.Response r = rest.request("POST", url, null, headers, body);
+        if (r.status >= 200 && r.status <= 299 && r.data.isJsonObject()) {
+            JsonObject obj = r.data.getAsJsonObject();
+            if (obj.has("data") && obj.get("data").isJsonObject()) {
+                JsonObject data = obj.getAsJsonObject("data");
+                if (data.has("token")) config.editToken = data.get("token").getAsString();
+                if (data.has("sid")) config.editSid = data.get("sid").getAsString();
+                if (data.has("rid")) config.editRid = data.get("rid").getAsString();
+                if (data.has("hsServerId")) config.serverId = data.get("hsServerId").getAsString();
+                if (data.has("dataCenter")) config.dataCenter = data.get("dataCenter").getAsString();
+                if (data.has("baseUrl")) config.baseUrl = data.get("baseUrl").getAsString();
+            }
+        }
+        return r.data;
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/api/MarginApi.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/api/MarginApi.java
@@ -1,0 +1,64 @@
+package com.kotak.neo.client.api;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.kotak.neo.client.Configuration;
+import com.kotak.neo.client.Settings;
+import com.kotak.neo.client.rest.RestClient;
+import com.kotak.neo.client.validation.Validators;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class MarginApi {
+    private final RestClient rest;
+    private final Configuration config;
+
+    public MarginApi(RestClient rest, Configuration config) {
+        this.rest = rest;
+        this.config = config;
+    }
+
+    public JsonElement marginRequired(MarginRequiredRequest r) {
+        Validators.validateMargin(r.exchangeSegment, r.price, r.orderType, r.product,
+                r.quantity, r.instrumentToken, r.transactionType);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("exSeg", Settings.EXCHANGE_SEGMENT.get(r.exchangeSegment));
+        body.put("prc", r.price);
+        body.put("prcTp", Settings.ORDER_TYPE.get(r.orderType));
+        body.put("prod", Settings.PRODUCT.get(r.product));
+        body.put("qty", r.quantity);
+        body.put("tok", r.instrumentToken);
+        body.put("trnsTp", r.transactionType);
+        body.put("trgPrc", r.triggerPrice);
+        body.put("brkName", r.brokerName == null ? "KOTAK" : r.brokerName);
+        body.put("brnchId", r.branchId == null ? "ONLINE" : r.branchId);
+        body.put("slAbsOrTks", r.stopLossType);
+        body.put("slVal", r.stopLossValue);
+        body.put("sqrOffAbsOrTks", r.squareOffType);
+        body.put("sqrOffVal", r.squareOffValue);
+        body.put("trailSL", r.trailingStopLoss);
+        body.put("tSLTks", r.trailingSLValue);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Sid", config.editSid == null ? "" : config.editSid);
+        headers.put("Auth", config.editToken == null ? "" : config.editToken);
+        headers.put("Content-Type", "application/x-www-form-urlencoded");
+
+        Map<String, String> query = new HashMap<>();
+        query.put("sId", config.serverId == null ? "" : config.serverId);
+
+        JsonElement resp = rest.request("POST", config.getUrl("margin"), query, headers, body).data;
+        JsonObject wrap = new JsonObject();
+        wrap.add("data", resp);
+        return wrap;
+    }
+
+    public static class MarginRequiredRequest {
+        public String exchangeSegment, price, orderType, product, quantity, instrumentToken, transactionType;
+        public String triggerPrice, brokerName, branchId, stopLossType, stopLossValue,
+                squareOffType, squareOffValue, trailingStopLoss, trailingSLValue;
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/api/OrderApi.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/api/OrderApi.java
@@ -1,0 +1,243 @@
+package com.kotak.neo.client.api;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.kotak.neo.client.Configuration;
+import com.kotak.neo.client.Settings;
+import com.kotak.neo.client.rest.RestClient;
+import com.kotak.neo.client.validation.Validators;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class OrderApi {
+    private final RestClient rest;
+    private final Configuration config;
+
+    public OrderApi(RestClient rest, Configuration config) {
+        this.rest = rest;
+        this.config = config;
+    }
+
+    private Map<String, String> authHeaders(String contentType) {
+        Map<String, String> h = new HashMap<>();
+        h.put("Sid", config.editSid == null ? "" : config.editSid);
+        h.put("Auth", config.editToken == null ? "" : config.editToken);
+        h.put("Content-Type", contentType);
+        return h;
+    }
+
+    private Map<String, String> serverId() {
+        Map<String, String> q = new HashMap<>();
+        q.put("sId", config.serverId == null ? "" : config.serverId);
+        return q;
+    }
+
+    public JsonElement placeOrder(PlaceOrderRequest r) {
+        Validators.validatePlaceOrder(r.exchangeSegment, r.product, r.price, r.orderType,
+                r.quantity, r.validity, r.tradingSymbol, r.transactionType);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("am", or(r.amo, "NO"));
+        body.put("dq", or(r.disclosedQuantity, "0"));
+        body.put("es", Settings.EXCHANGE_SEGMENT.get(r.exchangeSegment));
+        body.put("mp", or(r.marketProtection, "0"));
+        body.put("pc", Settings.PRODUCT.get(r.product));
+        body.put("pf", or(r.pf, "N"));
+        body.put("pr", r.price);
+        body.put("pt", Settings.ORDER_TYPE.get(r.orderType));
+        body.put("qt", r.quantity);
+        body.put("rt", r.validity);
+        body.put("tp", or(r.triggerPrice, "0"));
+        body.put("ts", r.tradingSymbol);
+        body.put("tt", r.transactionType);
+        body.put("ig", r.tag);
+        body.put("tk", r.scripToken);
+        body.put("sot", r.squareOffType);
+        body.put("slt", r.stopLossType);
+        body.put("slv", r.stopLossValue);
+        body.put("sov", r.squareOffValue);
+        body.put("lat", r.lastTradedPrice);
+        body.put("tlt", r.trailingStopLoss);
+        body.put("tsv", r.trailingSLValue);
+        body.put("os", Settings.ORDER_SOURCE);
+
+        return rest.request("POST", config.getUrl("place_order"), serverId(),
+                authHeaders("application/x-www-form-urlencoded"), body).data;
+    }
+
+    public JsonElement cancelOrder(String orderId, String amo, boolean verify) {
+        return cancelEndpoint("cancel_order", orderId, amo, verify);
+    }
+
+    public JsonElement cancelCoverOrder(String orderId, String amo, boolean verify) {
+        return cancelEndpoint("cancel_cover_order", orderId, amo, verify);
+    }
+
+    public JsonElement cancelBracketOrder(String orderId, String amo, boolean verify) {
+        return cancelEndpoint("cancel_bracket_order", orderId, amo, verify);
+    }
+
+    private JsonElement cancelEndpoint(String endpoint, String orderId, String amo, boolean verify) {
+        Validators.validateCancelOrder(orderId);
+        if (verify) {
+            JsonElement book = orderReport();
+            if (book.isJsonObject() && book.getAsJsonObject().has("data")
+                    && book.getAsJsonObject().get("data").isJsonArray()) {
+                for (JsonElement el : book.getAsJsonObject().getAsJsonArray("data")) {
+                    JsonObject row = el.getAsJsonObject();
+                    if (row.has("nOrdNo") && row.get("nOrdNo").getAsString().equals(orderId)
+                            && row.has("ordSt")) {
+                        String st = row.get("ordSt").getAsString();
+                        if (st.equals("rejected") || st.equals("cancelled")
+                                || st.equals("complete") || st.equals("traded")) {
+                            if (st.equals("complete")) st = "Traded";
+                            JsonObject err = new JsonObject();
+                            err.addProperty("Error", "The Given Order Status is " + st);
+                            err.addProperty("Reason", row.has("rejRsn") ? row.get("rejRsn").getAsString() : "");
+                            return err;
+                        }
+                    }
+                }
+            }
+        }
+        Map<String, Object> body = new HashMap<>();
+        body.put("on", orderId);
+        body.put("am", amo);
+        return rest.request("POST", config.getUrl(endpoint), serverId(),
+                authHeaders("application/x-www-form-urlencoded"), body).data;
+    }
+
+    public JsonElement modifyOrder(ModifyOrderRequest r) {
+        if (r.orderId == null || r.orderId.isEmpty())
+            throw new com.kotak.neo.client.exceptions.ApiValueError("order_id is mandatory");
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("tk", r.instrumentToken);
+        body.put("mp", or(r.marketProtection, "0"));
+        body.put("pc", r.product);
+        body.put("dd", or(r.dd, "NA"));
+        body.put("dq", or(r.disclosedQuantity, "0"));
+        body.put("vd", r.validity);
+        body.put("ts", r.tradingSymbol);
+        body.put("tt", r.transactionType);
+        body.put("pr", r.price);
+        body.put("pt", r.orderType);
+        body.put("fq", or(r.filledQuantity, "0"));
+        body.put("tp", or(r.triggerPrice, "0"));
+        body.put("qt", r.quantity);
+        body.put("no", r.orderId);
+        body.put("es", r.exchangeSegment);
+        body.put("am", or(r.amo, "NO"));
+        body.put("os", Settings.ORDER_SOURCE);
+
+        boolean hasAll = r.instrumentToken != null && r.exchangeSegment != null
+                && r.tradingSymbol != null && r.product != null;
+
+        if (hasAll) {
+            body.put("es", Settings.EXCHANGE_SEGMENT.get(r.exchangeSegment));
+            body.put("pc", Settings.PRODUCT.get(r.product));
+            body.put("pt", Settings.ORDER_TYPE.get(r.orderType));
+        } else {
+            JsonElement book = orderReport();
+            if (!book.isJsonObject() || !book.getAsJsonObject().has("data")
+                    || !book.getAsJsonObject().get("data").isJsonArray()) {
+                JsonObject m = new JsonObject();
+                m.addProperty("Message", "There is no Data in the Order Book");
+                return m;
+            }
+            JsonArray arr = book.getAsJsonObject().getAsJsonArray("data");
+            JsonObject match = null;
+            for (JsonElement el : arr) {
+                JsonObject row = el.getAsJsonObject();
+                if (row.has("nOrdNo") && row.get("nOrdNo").getAsString().equals(r.orderId)) {
+                    match = row; break;
+                }
+            }
+            if (match == null) {
+                JsonObject m = new JsonObject();
+                m.addProperty("Message", "The Given Order Number " + r.orderId + " is not matching with any of the orders");
+                return m;
+            }
+            if (match.has("ordSt")) {
+                String st = match.get("ordSt").getAsString();
+                if (st.equals("rejected") || st.equals("cancelled")
+                        || st.equals("complete") || st.equals("traded")) {
+                    if (st.equals("complete")) st = "Traded";
+                    JsonObject m = new JsonObject();
+                    m.addProperty("Error", "The Given Order Status is " + st + ", So we can't proceed further");
+                    m.addProperty("Reason", match.has("rejRsn") ? match.get("rejRsn").getAsString() : "");
+                    return m;
+                }
+            }
+            if (r.tradingSymbol == null && match.has("trdSym")) body.put("ts", match.get("trdSym").getAsString());
+            if (r.instrumentToken == null && match.has("tok")) body.put("tk", match.get("tok").getAsString());
+            if (r.product == null && match.has("prod")) body.put("pc", match.get("prod").getAsString());
+            if (r.transactionType == null && match.has("trnsTp")) body.put("tt", match.get("trnsTp").getAsString());
+            if (r.exchangeSegment == null && match.has("exSeg")) body.put("es", match.get("exSeg").getAsString());
+            if ("0".equals(or(r.triggerPrice, "0")) && match.has("trgPrc"))
+                body.put("tp", match.get("trgPrc").getAsString());
+        }
+
+        return rest.request("POST", config.getUrl("modify_order"), serverId(),
+                authHeaders("application/x-www-form-urlencoded"), body).data;
+    }
+
+    public JsonElement orderReport() {
+        Map<String, String> headers = authHeaders("application/x-www-form-urlencoded");
+        headers.put("accept", "application/json");
+        return rest.request("GET", config.getUrl("order_book"), serverId(), headers, null).data;
+    }
+
+    public JsonElement orderHistory(String orderId) {
+        Validators.validateOrderHistory(orderId);
+        Map<String, Object> body = new HashMap<>();
+        body.put("nOrdNo", orderId);
+        return rest.request("POST", config.getUrl("order_history"), serverId(),
+                authHeaders("application/x-www-form-urlencoded"), body).data;
+    }
+
+    public JsonElement tradeReport(String orderId) {
+        Map<String, String> headers = authHeaders("application/x-www-form-urlencoded");
+        headers.put("accept", "application/json");
+        JsonElement data = rest.request("GET", config.getUrl("trade_report"), serverId(), headers, null).data;
+        if (orderId == null || orderId.isEmpty()) return data;
+        if (!data.isJsonObject() || !data.getAsJsonObject().has("data")
+                || !data.getAsJsonObject().get("data").isJsonArray()) {
+            JsonObject err = new JsonObject();
+            err.addProperty("Error", "There is no trades available with the given order id");
+            return err;
+        }
+        for (JsonElement el : data.getAsJsonObject().getAsJsonArray("data")) {
+            JsonObject row = el.getAsJsonObject();
+            if (row.has("nOrdNo") && row.get("nOrdNo").getAsString().equals(orderId)) {
+                JsonObject out = new JsonObject();
+                if (data.getAsJsonObject().has("stat")) out.add("stat", data.getAsJsonObject().get("stat"));
+                if (data.getAsJsonObject().has("stCode")) out.add("stCode", data.getAsJsonObject().get("stCode"));
+                out.add("data", row);
+                return out;
+            }
+        }
+        JsonObject err = new JsonObject();
+        err.addProperty("Error", "There is no trades available with the given order id");
+        return err;
+    }
+
+    private static String or(String v, String d) { return v == null || v.isEmpty() ? d : v; }
+
+    public static class PlaceOrderRequest {
+        public String exchangeSegment, product, price, orderType, quantity, validity,
+                tradingSymbol, transactionType;
+        public String amo, disclosedQuantity, marketProtection, pf, triggerPrice,
+                tag, scripToken, squareOffType, stopLossType, stopLossValue,
+                squareOffValue, lastTradedPrice, trailingStopLoss, trailingSLValue;
+    }
+
+    public static class ModifyOrderRequest {
+        public String orderId, price, orderType, quantity, validity;
+        public String instrumentToken, exchangeSegment, product, tradingSymbol, transactionType,
+                triggerPrice, dd, marketProtection, disclosedQuantity, filledQuantity, amo;
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/api/PortfolioApi.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/api/PortfolioApi.java
@@ -1,0 +1,55 @@
+package com.kotak.neo.client.api;
+
+import com.google.gson.JsonElement;
+import com.kotak.neo.client.Configuration;
+import com.kotak.neo.client.rest.RestClient;
+import com.kotak.neo.client.validation.Validators;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PortfolioApi {
+    private final RestClient rest;
+    private final Configuration config;
+
+    public PortfolioApi(RestClient rest, Configuration config) {
+        this.rest = rest;
+        this.config = config;
+    }
+
+    private Map<String, String> auth(String ct) {
+        Map<String, String> h = new HashMap<>();
+        h.put("Sid", config.editSid == null ? "" : config.editSid);
+        h.put("Auth", config.editToken == null ? "" : config.editToken);
+        h.put("Content-Type", ct);
+        return h;
+    }
+
+    private Map<String, String> serverId() {
+        Map<String, String> q = new HashMap<>();
+        q.put("sId", config.serverId == null ? "" : config.serverId);
+        return q;
+    }
+
+    public JsonElement positions() {
+        Map<String, String> h = auth("application/x-www-form-urlencoded");
+        h.put("accept", "application/json");
+        return rest.request("GET", config.getUrl("positions"), serverId(), h, null).data;
+    }
+
+    public JsonElement holdings() {
+        Map<String, String> h = auth("application/x-www-form-urlencoded");
+        h.put("accept", "*/*");
+        return rest.request("GET", config.getUrl("holdings"), serverId(), h, null).data;
+    }
+
+    public JsonElement limits(String segment, String exchange, String product) {
+        Validators.validateLimits(segment, exchange, product);
+        Map<String, Object> body = new HashMap<>();
+        body.put("seg", segment);
+        body.put("exch", exchange);
+        body.put("prod", product);
+        return rest.request("POST", config.getUrl("limits"), serverId(),
+                auth("application/x-www-form-urlencoded"), body).data;
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/api/QuotesApi.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/api/QuotesApi.java
@@ -1,0 +1,48 @@
+package com.kotak.neo.client.api;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.kotak.neo.client.Configuration;
+import com.kotak.neo.client.rest.RestClient;
+import com.kotak.neo.client.websocket.Instrument;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class QuotesApi {
+    private final RestClient rest;
+    private final Configuration config;
+
+    public QuotesApi(RestClient rest, Configuration config) {
+        this.rest = rest;
+        this.config = config;
+    }
+
+    public JsonElement quotes(List<Instrument> instruments, String quoteType) {
+        if (instruments == null || instruments.isEmpty()) {
+            JsonObject err = new JsonObject();
+            com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+            JsonObject inner = new JsonObject();
+            inner.addProperty("message", "Validation Errors! instrument_tokens are missing");
+            arr.add(inner);
+            err.add("error", arr);
+            return err;
+        }
+        String qt = quoteType == null || quoteType.isEmpty() ? "all" : quoteType;
+        String joined = instruments.stream()
+                .map(i -> i.exchangeSegment + "|" + i.instrumentToken)
+                .collect(Collectors.joining(","));
+        String raw = config.getUrl("quotes_neo_symbol");
+        String url = raw.replace("{neo_symbols}", URLEncoder.encode(joined, StandardCharsets.UTF_8))
+                .replace("{quote_type}", qt);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", config.consumerKey == null ? "" : config.consumerKey);
+        headers.put("Content-Type", "application/x-www-form-urlencoded");
+        return rest.request("GET", url, null, headers, null).data;
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/api/ScripApi.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/api/ScripApi.java
@@ -1,0 +1,82 @@
+package com.kotak.neo.client.api;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.kotak.neo.client.Configuration;
+import com.kotak.neo.client.Settings;
+import com.kotak.neo.client.rest.RestClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ScripApi {
+    private final RestClient rest;
+    private final Configuration config;
+
+    public ScripApi(RestClient rest, Configuration config) {
+        this.rest = rest;
+        this.config = config;
+    }
+
+    public JsonElement scripMaster(String exchangeSegment) {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", config.consumerKey == null ? "" : config.consumerKey);
+        headers.put("Content-Type", "application/x-www-form-urlencoded");
+
+        RestClient.Response r = rest.request("GET", config.getUrl("scrip_master"), null, headers, null);
+        if (r.status != 200) return r.data;
+        if (!r.data.isJsonObject() || !r.data.getAsJsonObject().has("data")) return r.data;
+        JsonElement inner = r.data.getAsJsonObject().get("data");
+        if (exchangeSegment == null || exchangeSegment.isEmpty()) return inner;
+
+        String seg = Settings.EXCHANGE_SEGMENT.get(exchangeSegment);
+        if (seg == null) {
+            JsonObject err = new JsonObject();
+            err.addProperty("Error", "Exchange segment not found");
+            return err;
+        }
+        if (inner.isJsonObject() && inner.getAsJsonObject().has("filesPaths")
+                && inner.getAsJsonObject().get("filesPaths").isJsonArray()) {
+            for (JsonElement el : inner.getAsJsonObject().getAsJsonArray("filesPaths")) {
+                String p = el.getAsString();
+                if (p.toLowerCase().contains(seg.toLowerCase())) {
+                    JsonObject out = new JsonObject();
+                    out.addProperty("path", p);
+                    return out;
+                }
+            }
+        }
+        JsonObject err = new JsonObject();
+        err.addProperty("Error", "Exchange segment not found");
+        return err;
+    }
+
+    public JsonElement searchScrip(String exchangeSegment, String symbol, String expiry,
+                                   String optionType, String strikePrice) {
+        if (exchangeSegment == null || exchangeSegment.isEmpty()) {
+            JsonObject outer = new JsonObject();
+            com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+            JsonObject inner = new JsonObject();
+            inner.addProperty("code", "10300");
+            inner.addProperty("message", "Validation Errors! Exchange Segment is Mandate to proceed further");
+            arr.add(inner);
+            outer.add("error", arr);
+            return outer;
+        }
+        JsonElement master = scripMaster(exchangeSegment);
+        if (!master.isJsonObject() || !master.getAsJsonObject().has("path")) {
+            JsonObject err = new JsonObject();
+            err.addProperty("Error", "Exchange Segment is not available");
+            return err;
+        }
+        JsonObject out = new JsonObject();
+        out.addProperty("exchange_segment", exchangeSegment);
+        out.addProperty("symbol", symbol == null ? "" : symbol.toLowerCase());
+        if (expiry != null) out.addProperty("expiry", expiry);
+        if (optionType != null) out.addProperty("option_type", optionType);
+        if (strikePrice != null) out.addProperty("strike_price", strikePrice);
+        out.addProperty("csv_url", master.getAsJsonObject().get("path").getAsString());
+        out.addProperty("hint", "Download csv_url and filter client-side by symbol/expiry/strike");
+        return out;
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/exceptions/ApiAttributeError.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/exceptions/ApiAttributeError.java
@@ -1,0 +1,5 @@
+package com.kotak.neo.client.exceptions;
+
+public class ApiAttributeError extends OpenApiException {
+    public ApiAttributeError(String msg) { super(msg); }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/exceptions/ApiException.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/exceptions/ApiException.java
@@ -1,0 +1,14 @@
+package com.kotak.neo.client.exceptions;
+
+public class ApiException extends OpenApiException {
+    public final int status;
+    public final String reason;
+    public final String body;
+
+    public ApiException(int status, String reason, String body) {
+        super(String.format("(%d) %s%s", status, reason, body == null ? "" : ": " + body));
+        this.status = status;
+        this.reason = reason;
+        this.body = body;
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/exceptions/ApiKeyError.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/exceptions/ApiKeyError.java
@@ -1,0 +1,5 @@
+package com.kotak.neo.client.exceptions;
+
+public class ApiKeyError extends OpenApiException {
+    public ApiKeyError(String msg) { super(msg); }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/exceptions/ApiTypeError.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/exceptions/ApiTypeError.java
@@ -1,0 +1,5 @@
+package com.kotak.neo.client.exceptions;
+
+public class ApiTypeError extends OpenApiException {
+    public ApiTypeError(String msg) { super(msg); }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/exceptions/ApiValueError.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/exceptions/ApiValueError.java
@@ -1,0 +1,5 @@
+package com.kotak.neo.client.exceptions;
+
+public class ApiValueError extends OpenApiException {
+    public ApiValueError(String msg) { super(msg); }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/exceptions/OpenApiException.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/exceptions/OpenApiException.java
@@ -1,0 +1,7 @@
+package com.kotak.neo.client.exceptions;
+
+public class OpenApiException extends RuntimeException {
+    public OpenApiException(String message) {
+        super(message);
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/rest/RestClient.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/rest/RestClient.java
@@ -1,0 +1,102 @@
+package com.kotak.neo.client.rest;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.kotak.neo.client.Configuration;
+import com.kotak.neo.client.exceptions.ApiException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RestClient {
+    private static final Gson GSON = new Gson();
+    private final HttpClient http;
+    public final Configuration config;
+
+    public RestClient(Configuration config) {
+        this.config = config;
+        this.http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build();
+    }
+
+    public static class Response {
+        public int status;
+        public String text;
+        public JsonElement data;
+    }
+
+    public Response request(String method, String url, Map<String, String> queryParams,
+                            Map<String, String> headers, Object body) {
+        method = method.toUpperCase();
+        if (headers == null) headers = new java.util.HashMap<>();
+        headers.putIfAbsent("Content-Type", "application/json");
+        headers.putIfAbsent("User-Agent", "NeoTradeApi-java/1.0.0");
+
+        if (queryParams != null && !queryParams.isEmpty()) {
+            String qs = queryParams.entrySet().stream()
+                    .map(e -> enc(e.getKey()) + "=" + enc(e.getValue()))
+                    .collect(Collectors.joining("&"));
+            url += (url.contains("?") ? "&" : "?") + qs;
+        }
+
+        HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(url));
+        HttpRequest.BodyPublisher bodyPublisher = HttpRequest.BodyPublishers.noBody();
+
+        String ct = headers.get("Content-Type");
+        if (method.equals("POST") || method.equals("PUT") || method.equals("PATCH") || method.equals("DELETE")) {
+            if (ct.toLowerCase().contains("json")) {
+                String payload = body == null ? "" : GSON.toJson(body);
+                bodyPublisher = HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8);
+            } else if (ct.toLowerCase().contains("x-www-form-urlencoded")) {
+                String payload = "";
+                if (body != null) {
+                    payload = "jData=" + enc(GSON.toJson(body));
+                }
+                bodyPublisher = HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8);
+            } else {
+                throw new ApiException(0, "Invalid Content-Type", ct);
+            }
+        }
+
+        switch (method) {
+            case "GET": b.GET(); break;
+            case "DELETE": b.method("DELETE", bodyPublisher); break;
+            default: b.method(method, bodyPublisher);
+        }
+
+        for (Map.Entry<String, String> h : headers.entrySet()) {
+            // Restricted headers cannot be set directly; let the JDK add them.
+            try { b.header(h.getKey(), h.getValue()); } catch (IllegalArgumentException ignored) { }
+        }
+
+        try {
+            HttpResponse<String> resp = http.send(b.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            Response r = new Response();
+            r.status = resp.statusCode();
+            r.text = resp.body() == null ? "" : resp.body();
+            try {
+                r.data = r.text.isEmpty() ? new JsonObject() : JsonParser.parseString(r.text);
+            } catch (Exception parseFail) {
+                JsonObject obj = new JsonObject();
+                obj.addProperty("raw", r.text);
+                r.data = obj;
+            }
+            return r;
+        } catch (IOException | InterruptedException e) {
+            throw new ApiException(0, "http error", e.getMessage());
+        }
+    }
+
+    private static String enc(String s) {
+        return URLEncoder.encode(s == null ? "" : s, StandardCharsets.UTF_8);
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/rest/RestClient.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/rest/RestClient.java
@@ -91,7 +91,10 @@ public class RestClient {
                 r.data = obj;
             }
             return r;
-        } catch (IOException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ApiException(0, "http error", e.getMessage());
+        } catch (IOException e) {
             throw new ApiException(0, "http error", e.getMessage());
         }
     }

--- a/client/java-client/src/main/java/com/kotak/neo/client/validation/Validators.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/validation/Validators.java
@@ -1,0 +1,61 @@
+package com.kotak.neo.client.validation;
+
+import com.kotak.neo.client.Settings;
+import com.kotak.neo.client.exceptions.ApiValueError;
+
+public final class Validators {
+    private Validators() {}
+
+    private static void nonEmpty(String val, String name) {
+        if (val == null || val.trim().isEmpty())
+            throw new ApiValueError(name + " is mandatory");
+    }
+
+    public static void validatePlaceOrder(String exchangeSegment, String product, String price,
+                                          String orderType, String quantity, String validity,
+                                          String tradingSymbol, String transactionType) {
+        nonEmpty(exchangeSegment, "exchange_segment");
+        nonEmpty(product, "product");
+        nonEmpty(price, "price");
+        nonEmpty(orderType, "order_type");
+        nonEmpty(quantity, "quantity");
+        nonEmpty(validity, "validity");
+        nonEmpty(tradingSymbol, "trading_symbol");
+        nonEmpty(transactionType, "transaction_type");
+        if (!Settings.EXCHANGE_SEGMENT.containsKey(exchangeSegment))
+            throw new ApiValueError("invalid exchange_segment: " + exchangeSegment);
+        if (!Settings.PRODUCT.containsKey(product))
+            throw new ApiValueError("invalid product: " + product);
+        if (!Settings.ORDER_TYPE.containsKey(orderType))
+            throw new ApiValueError("invalid order_type: " + orderType);
+        String tt = transactionType.toUpperCase();
+        if (!tt.equals("B") && !tt.equals("S") && !tt.equals("BUY") && !tt.equals("SELL"))
+            throw new ApiValueError("transaction_type must be B/S");
+    }
+
+    public static void validateCancelOrder(String orderId) { nonEmpty(orderId, "order_id"); }
+    public static void validateOrderHistory(String orderId) { nonEmpty(orderId, "order_id"); }
+
+    public static void validateMargin(String exchangeSegment, String price, String orderType,
+                                      String product, String quantity, String instrumentToken,
+                                      String transactionType) {
+        nonEmpty(exchangeSegment, "exchange_segment");
+        nonEmpty(price, "price");
+        nonEmpty(orderType, "order_type");
+        nonEmpty(product, "product");
+        nonEmpty(quantity, "quantity");
+        nonEmpty(instrumentToken, "instrument_token");
+        nonEmpty(transactionType, "transaction_type");
+        if (!Settings.EXCHANGE_SEGMENT.containsKey(exchangeSegment))
+            throw new ApiValueError("invalid exchange_segment: " + exchangeSegment);
+    }
+
+    public static void validateLimits(String segment, String exchange, String product) {
+        if (!Settings.SEGMENT_LIMITS.contains(segment))
+            throw new ApiValueError("invalid segment: " + segment);
+        if (!Settings.EXCHANGE_LIMITS.contains(exchange))
+            throw new ApiValueError("invalid exchange: " + exchange);
+        if (!Settings.PRODUCT_LIMITS.contains(product))
+            throw new ApiValueError("invalid product: " + product);
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/validation/Validators.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/validation/Validators.java
@@ -3,7 +3,13 @@ package com.kotak.neo.client.validation;
 import com.kotak.neo.client.Settings;
 import com.kotak.neo.client.exceptions.ApiValueError;
 
+import java.util.Set;
+
 public final class Validators {
+    private static final Set<String> VALIDITY_VALUES = Set.of("DAY", "IOC");
+    private static final Set<String> PLACE_ORDER_TT = Set.of("B", "S", "Buy", "Sell");
+    private static final Set<String> MARGIN_TT = Set.of("B", "S", "Buy", "Sell", "sell", "buy");
+
     private Validators() {}
 
     private static void nonEmpty(String val, String name) {
@@ -28,9 +34,10 @@ public final class Validators {
             throw new ApiValueError("invalid product: " + product);
         if (!Settings.ORDER_TYPE.containsKey(orderType))
             throw new ApiValueError("invalid order_type: " + orderType);
-        String tt = transactionType.toUpperCase();
-        if (!tt.equals("B") && !tt.equals("S") && !tt.equals("BUY") && !tt.equals("SELL"))
-            throw new ApiValueError("transaction_type must be B/S");
+        if (!VALIDITY_VALUES.contains(validity))
+            throw new ApiValueError("Invalid validity. Allowed values are DAY, IOC.");
+        if (!PLACE_ORDER_TT.contains(transactionType))
+            throw new ApiValueError("Invalid transaction type. Allowed values are B or Buy, S or Sell.");
     }
 
     public static void validateCancelOrder(String orderId) { nonEmpty(orderId, "order_id"); }
@@ -48,6 +55,12 @@ public final class Validators {
         nonEmpty(transactionType, "transaction_type");
         if (!Settings.EXCHANGE_SEGMENT.containsKey(exchangeSegment))
             throw new ApiValueError("invalid exchange_segment: " + exchangeSegment);
+        if (!Settings.PRODUCT.containsKey(product))
+            throw new ApiValueError("invalid product: " + product);
+        if (!Settings.ORDER_TYPE.containsKey(orderType))
+            throw new ApiValueError("invalid order_type: " + orderType);
+        if (!MARGIN_TT.contains(transactionType))
+            throw new ApiValueError("Invalid transaction type. Allowed values are B or Buy, S or Sell.");
     }
 
     public static void validateLimits(String segment, String exchange, String product) {

--- a/client/java-client/src/main/java/com/kotak/neo/client/websocket/HsWebSocketCodec.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/websocket/HsWebSocketCodec.java
@@ -1,0 +1,42 @@
+package com.kotak.neo.client.websocket;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Binary frame parser for the HSM market-data WebSocket.
+ * Matches the structural port in the Go / .NET / TypeScript clients.
+ */
+public final class HsWebSocketCodec {
+    private HsWebSocketCodec() {}
+
+    public static class Frame {
+        public int packetType;
+        public byte[] payload;
+    }
+
+    public static List<Frame> decode(byte[] buf) {
+        List<Frame> out = new ArrayList<>();
+        if (buf == null || buf.length < 1) return out;
+        int count = buf[0] & 0xFF;
+        int pos = 1;
+        ByteBuffer bb = ByteBuffer.wrap(buf).order(ByteOrder.BIG_ENDIAN);
+        for (int i = 0; i < count; i++) {
+            if (pos + 2 > buf.length) break;
+            bb.position(pos);
+            int len = bb.getShort() & 0xFFFF;
+            pos += 2;
+            if (pos + len > buf.length) break;
+            if (len < 1) { pos += len; continue; }
+            Frame f = new Frame();
+            f.packetType = buf[pos] & 0xFF;
+            f.payload = new byte[len - 1];
+            System.arraycopy(buf, pos + 1, f.payload, 0, len - 1);
+            out.add(f);
+            pos += len;
+        }
+        return out;
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/websocket/Instrument.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/websocket/Instrument.java
@@ -1,0 +1,13 @@
+package com.kotak.neo.client.websocket;
+
+public class Instrument {
+    public String instrumentToken;
+    public String exchangeSegment;
+
+    public Instrument() {}
+
+    public Instrument(String instrumentToken, String exchangeSegment) {
+        this.instrumentToken = instrumentToken;
+        this.exchangeSegment = exchangeSegment;
+    }
+}

--- a/client/java-client/src/main/java/com/kotak/neo/client/websocket/NeoWebSocket.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/websocket/NeoWebSocket.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -32,7 +33,13 @@ public class NeoWebSocket {
 
     private WebSocketClient marketClient;
     private WebSocketClient orderClient;
-    private final ScheduledExecutorService heartbeatPool = Executors.newScheduledThreadPool(2);
+    private final ScheduledExecutorService heartbeatPool = Executors.newScheduledThreadPool(2, r -> {
+        Thread t = new Thread(r, "neo-ws-heartbeat");
+        t.setDaemon(true);
+        return t;
+    });
+    private volatile ScheduledFuture<?> marketHeartbeat;
+    private volatile ScheduledFuture<?> orderHeartbeat;
 
     public Consumer<String> onOpen;
     public Consumer<Object> onMessage;
@@ -99,7 +106,7 @@ public class NeoWebSocket {
                 handshake.put("Sid", sid);
                 send(GSON.toJson(handshake));
                 if (onOpen != null) onOpen.accept("market socket opened");
-                heartbeatPool.scheduleAtFixedRate(() -> {
+                marketHeartbeat = heartbeatPool.scheduleAtFixedRate(() -> {
                     if (isOpen()) send("{\"type\":\"hb\"}");
                 }, 29, 29, TimeUnit.SECONDS);
             }
@@ -120,13 +127,31 @@ public class NeoWebSocket {
                 }
             }
             @Override public void onClose(int code, String reason, boolean remote) {
+                cancelMarketHeartbeat();
                 if (onClose != null) onClose.accept("market socket closed");
             }
             @Override public void onError(Exception ex) {
+                cancelMarketHeartbeat();
                 if (onError != null) onError.accept(ex);
             }
         };
         marketClient.connectBlocking();
+    }
+
+    private void cancelMarketHeartbeat() {
+        ScheduledFuture<?> f = marketHeartbeat;
+        if (f != null) {
+            f.cancel(false);
+            marketHeartbeat = null;
+        }
+    }
+
+    private void cancelOrderHeartbeat() {
+        ScheduledFuture<?> f = orderHeartbeat;
+        if (f != null) {
+            f.cancel(false);
+            orderHeartbeat = null;
+        }
     }
 
     private void openOrder() throws Exception {
@@ -150,7 +175,7 @@ public class NeoWebSocket {
                 handshake.put("source", "WEB");
                 send(GSON.toJson(handshake));
                 if (onOpen != null) onOpen.accept("order feed opened");
-                heartbeatPool.scheduleAtFixedRate(() -> {
+                orderHeartbeat = heartbeatPool.scheduleAtFixedRate(() -> {
                     if (isOpen()) send("{\"type\":\"HB\"}");
                 }, 30, 30, TimeUnit.SECONDS);
             }
@@ -167,9 +192,11 @@ public class NeoWebSocket {
                 }
             }
             @Override public void onClose(int code, String reason, boolean remote) {
+                cancelOrderHeartbeat();
                 if (onClose != null) onClose.accept("order feed closed");
             }
             @Override public void onError(Exception ex) {
+                cancelOrderHeartbeat();
                 if (onError != null) onError.accept(ex);
             }
         };

--- a/client/java-client/src/main/java/com/kotak/neo/client/websocket/NeoWebSocket.java
+++ b/client/java-client/src/main/java/com/kotak/neo/client/websocket/NeoWebSocket.java
@@ -1,0 +1,191 @@
+package com.kotak.neo.client.websocket;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParser;
+import com.kotak.neo.client.Settings;
+import com.kotak.neo.client.Urls;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/**
+ * NeoWebSocket manages market-data and order-feed WebSocket connections.
+ * Mirrors the Python NeoWebSocket class.
+ */
+public class NeoWebSocket {
+    private static final Gson GSON = new Gson();
+
+    private final String sid;
+    private final String token;
+    private final String serverId;
+    private final String dataCenter;
+
+    private WebSocketClient marketClient;
+    private WebSocketClient orderClient;
+    private final ScheduledExecutorService heartbeatPool = Executors.newScheduledThreadPool(2);
+
+    public Consumer<String> onOpen;
+    public Consumer<Object> onMessage;
+    public Consumer<Throwable> onError;
+    public Consumer<String> onClose;
+
+    public NeoWebSocket(String sid, String token, String serverId, String dataCenter) {
+        this.sid = sid;
+        this.token = token;
+        this.serverId = serverId;
+        this.dataCenter = dataCenter;
+    }
+
+    public void getLiveFeed(List<Instrument> instruments, boolean isIndex, boolean isDepth) throws Exception {
+        String subType = Settings.REQ_TYPE_VALUES.get("SCRIP_SUBS");
+        if (isIndex) subType = Settings.REQ_TYPE_VALUES.get("INDEX_SUBS");
+        if (isDepth) subType = Settings.REQ_TYPE_VALUES.get("DEPTH_SUBS");
+
+        if (marketClient == null || !marketClient.isOpen()) openMarket();
+
+        String scrips = instruments.stream()
+                .map(i -> i.exchangeSegment + "|" + i.instrumentToken)
+                .collect(Collectors.joining("&"));
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("type", subType);
+        payload.put("scrips", scrips);
+        payload.put("channelnum", 2);
+        marketClient.send(GSON.toJson(payload));
+    }
+
+    public void unSubscribeList(List<Instrument> instruments, boolean isIndex, boolean isDepth) {
+        if (marketClient == null || !marketClient.isOpen())
+            throw new IllegalStateException("Socket Connection has been closed");
+        String unsub = Settings.REQ_TYPE_VALUES.get("SCRIP_UNSUBS");
+        if (isIndex) unsub = Settings.REQ_TYPE_VALUES.get("INDEX_UNSUBS");
+        if (isDepth) unsub = Settings.REQ_TYPE_VALUES.get("DEPTH_UNSUBS");
+        String scrips = instruments.stream()
+                .map(i -> i.exchangeSegment + "|" + i.instrumentToken)
+                .collect(Collectors.joining("&"));
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("type", unsub);
+        payload.put("scrips", scrips);
+        payload.put("channelnum", 2);
+        marketClient.send(GSON.toJson(payload));
+    }
+
+    public void getOrderFeed() throws Exception {
+        if (orderClient != null && orderClient.isOpen()) return;
+        openOrder();
+    }
+
+    public void close() {
+        if (marketClient != null) marketClient.close();
+        if (orderClient != null) orderClient.close();
+        heartbeatPool.shutdownNow();
+    }
+
+    private void openMarket() throws Exception {
+        marketClient = new WebSocketClient(new URI(Urls.WEBSOCKET_URL)) {
+            @Override public void onOpen(ServerHandshake hs) {
+                Map<String, Object> handshake = new HashMap<>();
+                handshake.put("type", "cn");
+                handshake.put("Authorization", token);
+                handshake.put("Sid", sid);
+                send(GSON.toJson(handshake));
+                if (onOpen != null) onOpen.accept("market socket opened");
+                heartbeatPool.scheduleAtFixedRate(() -> {
+                    if (isOpen()) send("{\"type\":\"hb\"}");
+                }, 29, 29, TimeUnit.SECONDS);
+            }
+            @Override public void onMessage(String msg) { handleMarketText(msg); }
+            @Override public void onMessage(ByteBuffer bytes) {
+                byte[] buf = new byte[bytes.remaining()];
+                bytes.get(buf);
+                try {
+                    List<HsWebSocketCodec.Frame> frames = HsWebSocketCodec.decode(buf);
+                    if (onMessage != null) {
+                        Map<String, Object> out = new HashMap<>();
+                        out.put("type", "stock_feed");
+                        out.put("data", frames);
+                        onMessage.accept(out);
+                    }
+                } catch (Throwable t) {
+                    if (onError != null) onError.accept(t);
+                }
+            }
+            @Override public void onClose(int code, String reason, boolean remote) {
+                if (onClose != null) onClose.accept("market socket closed");
+            }
+            @Override public void onError(Exception ex) {
+                if (onError != null) onError.accept(ex);
+            }
+        };
+        marketClient.connectBlocking();
+    }
+
+    private void openOrder() throws Exception {
+        String url = Urls.ORDER_FEED_URL;
+        if (dataCenter != null) {
+            switch (dataCenter.toLowerCase()) {
+                case "adc": url = Urls.ORDER_FEED_URL_ADC; break;
+                case "e21": url = Urls.ORDER_FEED_URL_E21; break;
+                case "e22": url = Urls.ORDER_FEED_URL_E22; break;
+                case "e41": url = Urls.ORDER_FEED_URL_E41; break;
+                case "e43": url = Urls.ORDER_FEED_URL_E43; break;
+                default: break;
+            }
+        }
+        orderClient = new WebSocketClient(new URI(url)) {
+            @Override public void onOpen(ServerHandshake hs) {
+                Map<String, Object> handshake = new HashMap<>();
+                handshake.put("type", "CONNECTION");
+                handshake.put("Authorization", token);
+                handshake.put("Sid", sid);
+                handshake.put("source", "WEB");
+                send(GSON.toJson(handshake));
+                if (onOpen != null) onOpen.accept("order feed opened");
+                heartbeatPool.scheduleAtFixedRate(() -> {
+                    if (isOpen()) send("{\"type\":\"HB\"}");
+                }, 30, 30, TimeUnit.SECONDS);
+            }
+            @Override public void onMessage(String msg) {
+                try {
+                    if (onMessage != null) {
+                        Map<String, Object> out = new HashMap<>();
+                        out.put("type", "order_feed");
+                        out.put("data", JsonParser.parseString(msg));
+                        onMessage.accept(out);
+                    }
+                } catch (Throwable t) {
+                    if (onMessage != null) onMessage.accept(msg);
+                }
+            }
+            @Override public void onClose(int code, String reason, boolean remote) {
+                if (onClose != null) onClose.accept("order feed closed");
+            }
+            @Override public void onError(Exception ex) {
+                if (onError != null) onError.accept(ex);
+            }
+        };
+        orderClient.connectBlocking();
+    }
+
+    private void handleMarketText(String msg) {
+        try {
+            if (onMessage != null) {
+                Map<String, Object> out = new HashMap<>();
+                out.put("type", "stock_feed");
+                out.put("data", JsonParser.parseString(msg));
+                onMessage.accept(out);
+            }
+        } catch (Throwable t) {
+            if (onMessage != null) onMessage.accept(msg);
+        }
+    }
+}

--- a/client/typescript-client/README.md
+++ b/client/typescript-client/README.md
@@ -1,0 +1,65 @@
+# Kotak Neo — TypeScript client
+
+Node/TypeScript port of the Python `neo_api_client`.
+
+## Install
+
+```bash
+cd client/typescript-client
+npm install
+npm run typecheck
+```
+
+## Quickstart
+
+```typescript
+import { NeoAPI } from "@kotak-neo/client";
+
+const client = new NeoAPI({
+  environment: "prod",
+  consumerKey: "YOUR_CONSUMER_KEY",
+});
+
+await client.totpLogin("+919999999999", "ABC12", "123456");
+await client.totpValidate("1234");
+
+const resp = await client.placeOrder({
+  exchange_segment: "nse_cm",
+  product: "MIS",
+  price: "100.50",
+  order_type: "L",
+  quantity: "1",
+  validity: "DAY",
+  trading_symbol: "RELIANCE-EQ",
+  transaction_type: "B",
+});
+console.log(resp);
+```
+
+## Streaming
+
+```typescript
+client.onMessage = (m) => console.log(m);
+await client.subscribe([
+  { instrument_token: "11536", exchange_segment: "nse_cm" },
+]);
+```
+
+## Method map (Python → TypeScript)
+
+| Python | TypeScript |
+|---|---|
+| `totp_login` / `totp_validate` / `logout` | `totpLogin` / `totpValidate` / `logout` |
+| `place_order` / `modify_order` | `placeOrder` / `modifyOrder` |
+| `cancel_order` / `cancel_cover_order` / `cancel_bracket_order` | `cancelOrder` / `cancelCoverOrder` / `cancelBracketOrder` |
+| `order_report` / `order_history` / `trade_report` | `orderReport` / `orderHistory` / `tradeReport` |
+| `positions` / `holdings` / `limits` | `positions` / `holdings` / `limits` |
+| `margin_required` | `marginRequired` |
+| `scrip_master` / `search_scrip` | `scripMaster` / `searchScrip` |
+| `quotes` | `quotes` |
+| `subscribe` / `un_subscribe` | `subscribe` / `unSubscribe` |
+| `subscribe_to_orderfeed` | `subscribeToOrderFeed` |
+
+## Node-only WebSocket
+
+Uses [`ws`](https://www.npmjs.com/package/ws) which is Node-only. For browser use, swap with the native `WebSocket` API by editing `src/websocket/NeoWebSocket.ts`.

--- a/client/typescript-client/examples/demo.ts
+++ b/client/typescript-client/examples/demo.ts
@@ -1,0 +1,29 @@
+import { NeoAPI } from "../src";
+
+async function main(): Promise<void> {
+  const env = process.env.NEO_ENV || "uat";
+  const consumer = process.env.NEO_CONSUMER || "";
+  const mobile = process.env.NEO_MOBILE;
+  const ucc = process.env.NEO_UCC;
+  const totp = process.env.NEO_TOTP;
+  const mpin = process.env.NEO_MPIN;
+
+  const client = new NeoAPI({ environment: env, consumerKey: consumer });
+
+  client.onOpen = (m) => console.log("[ws] open:", m);
+  client.onMessage = (m) => console.log("[ws] msg:", m);
+  client.onError = (e) => console.log("[ws] err:", e);
+  client.onClose = (m) => console.log("[ws] close:", m);
+
+  if (!mobile || !ucc || !totp || !mpin) {
+    console.log("Set NEO_MOBILE, NEO_UCC, NEO_TOTP, NEO_MPIN to exercise login.");
+    console.log("Client constructed OK; skipping live calls.");
+    return;
+  }
+
+  console.log("totp_login:", await client.totpLogin(mobile, ucc, totp));
+  console.log("totp_validate:", await client.totpValidate(mpin));
+  console.log("order_report:", await client.orderReport());
+}
+
+main().catch(console.error);

--- a/client/typescript-client/package-lock.json
+++ b/client/typescript-client/package-lock.json
@@ -1,0 +1,273 @@
+{
+  "name": "@kotak-neo/client",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@kotak-neo/client",
+      "version": "1.0.0",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "@types/ws": "^8.5.10",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/client/typescript-client/package.json
+++ b/client/typescript-client/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@kotak-neo/client",
+  "version": "1.0.0",
+  "description": "TypeScript client for the Kotak Neo trading API.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "example": "ts-node examples/demo.ts"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/ws": "^8.5.10",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/client/typescript-client/src/NeoAPI.ts
+++ b/client/typescript-client/src/NeoAPI.ts
@@ -1,0 +1,213 @@
+import { Configuration } from "./configuration";
+import { RestClient, Response } from "./rest";
+import { LoginApi } from "./api/loginApi";
+import { OrderApi } from "./api/orderApi";
+import { PortfolioApi } from "./api/portfolioApi";
+import { MarginApi } from "./api/marginApi";
+import { ScripApi } from "./api/scripApi";
+import { QuotesApi } from "./api/quotesApi";
+import { NeoWebSocket } from "./websocket/NeoWebSocket";
+import {
+  PlaceOrderRequest,
+  ModifyOrderRequest,
+  MarginRequiredRequest,
+  Instrument,
+  QuoteInstrument,
+  MessageCallback,
+  ErrorCallback,
+  VoidCallback,
+} from "./types";
+
+/**
+ * NeoAPI — top-level SDK entry point. Mirrors the Python NeoAPI class.
+ */
+export class NeoAPI {
+  readonly configuration: Configuration;
+  private rest: RestClient;
+  private loginApi: LoginApi;
+  private orderApi: OrderApi;
+  private portfolioApi: PortfolioApi;
+  private marginApi: MarginApi;
+  private scripApi: ScripApi;
+  private quotesApi: QuotesApi;
+  private neoWebSocket?: NeoWebSocket;
+
+  onOpen?: VoidCallback;
+  onMessage?: MessageCallback;
+  onError?: ErrorCallback;
+  onClose?: VoidCallback;
+
+  constructor(opts: {
+    environment?: string;
+    accessToken?: string;
+    neoFinKey?: string;
+    consumerKey?: string;
+  } = {}) {
+    this.configuration = new Configuration(opts.environment || "uat");
+    this.configuration.bearerToken = opts.accessToken;
+    this.configuration.neoFinKey = opts.neoFinKey;
+    this.configuration.consumerKey = opts.consumerKey;
+
+    this.rest = new RestClient(this.configuration);
+    this.loginApi = new LoginApi(this.rest, this.configuration);
+    this.orderApi = new OrderApi(this.rest, this.configuration);
+    this.portfolioApi = new PortfolioApi(this.rest, this.configuration);
+    this.marginApi = new MarginApi(this.rest, this.configuration);
+    this.scripApi = new ScripApi(this.rest, this.configuration);
+    this.quotesApi = new QuotesApi(this.rest, this.configuration);
+  }
+
+  private requireLogin(): Response | null {
+    if (!this.configuration.isLoggedIn()) {
+      return { "Error Message": "Complete the 2fa process before accessing this application" };
+    }
+    return null;
+  }
+
+  // ---------- Auth ----------
+  totpLogin(mobileNumber: string, ucc: string, totp: string): Promise<Response> {
+    return this.loginApi.totpLogin(mobileNumber, ucc, totp);
+  }
+  totpValidate(mpin: string): Promise<Response> {
+    return this.loginApi.totpValidate(mpin);
+  }
+  logout(): Response {
+    const e = this.requireLogin();
+    if (e) return e;
+    this.configuration.bearerToken = undefined;
+    this.configuration.editSid = undefined;
+    this.configuration.editToken = undefined;
+    return { State: "OK", message: "You have been successfully logged out" };
+  }
+
+  // ---------- Orders ----------
+  async placeOrder(req: PlaceOrderRequest): Promise<Response> {
+    const e = this.requireLogin();
+    if (e) return e;
+    try {
+      return await this.orderApi.placeOrder(req);
+    } catch (err) {
+      return { Error: (err as Error).message };
+    }
+  }
+  async modifyOrder(req: ModifyOrderRequest): Promise<Response> {
+    const e = this.requireLogin();
+    if (e) return e;
+    try {
+      return await this.orderApi.modifyOrder(req, () => this.orderApi.orderReport());
+    } catch (err) {
+      return { Error: (err as Error).message };
+    }
+  }
+  async cancelOrder(orderId: string, amo = "NO", verify = false): Promise<Response> {
+    const e = this.requireLogin();
+    if (e) return e;
+    try {
+      return await this.orderApi.cancelOrder(orderId, amo, verify, () => this.orderApi.orderReport());
+    } catch (err) {
+      return { Error: (err as Error).message };
+    }
+  }
+  async cancelCoverOrder(orderId: string, amo = "NO", verify = false): Promise<Response> {
+    const e = this.requireLogin();
+    if (e) return e;
+    try {
+      return await this.orderApi.cancelCoverOrder(orderId, amo, verify, () => this.orderApi.orderReport());
+    } catch (err) {
+      return { Error: (err as Error).message };
+    }
+  }
+  async cancelBracketOrder(orderId: string, amo = "NO", verify = false): Promise<Response> {
+    const e = this.requireLogin();
+    if (e) return e;
+    try {
+      return await this.orderApi.cancelBracketOrder(orderId, amo, verify, () => this.orderApi.orderReport());
+    } catch (err) {
+      return { Error: (err as Error).message };
+    }
+  }
+
+  // ---------- Reports ----------
+  async orderReport(): Promise<Response> {
+    const e = this.requireLogin(); if (e) return e;
+    try { return await this.orderApi.orderReport(); } catch (err) { return { Error: (err as Error).message }; }
+  }
+  async orderHistory(orderId: string): Promise<Response> {
+    const e = this.requireLogin(); if (e) return e;
+    try { return await this.orderApi.orderHistory(orderId); } catch (err) { return { Error: (err as Error).message }; }
+  }
+  async tradeReport(orderId?: string): Promise<Response> {
+    const e = this.requireLogin(); if (e) return e;
+    try { return await this.orderApi.tradeReport(orderId); } catch (err) { return { Error: (err as Error).message }; }
+  }
+
+  // ---------- Portfolio ----------
+  async positions(): Promise<Response> {
+    const e = this.requireLogin(); if (e) return e;
+    try { return await this.portfolioApi.positions(); } catch (err) { return { Error: (err as Error).message }; }
+  }
+  async holdings(): Promise<Response> {
+    const e = this.requireLogin(); if (e) return e;
+    try { return await this.portfolioApi.holdings(); } catch (err) { return { Error: (err as Error).message }; }
+  }
+  async limits(segment = "ALL", exchange = "ALL", product = "ALL"): Promise<Response> {
+    const e = this.requireLogin(); if (e) return e;
+    try { return await this.portfolioApi.limits(segment, exchange, product); } catch (err) { return { Error: (err as Error).message }; }
+  }
+
+  // ---------- Pricing ----------
+  async marginRequired(req: MarginRequiredRequest): Promise<Response> {
+    const e = this.requireLogin(); if (e) return e;
+    try { return await this.marginApi.marginRequired(req); } catch (err) { return { Error: (err as Error).message }; }
+  }
+  quotes(instruments: QuoteInstrument[], quoteType?: string): Promise<Response> {
+    return this.quotesApi.quotes(instruments, quoteType);
+  }
+
+  // ---------- Scrip ----------
+  async scripMaster(exchangeSegment?: string): Promise<Response> {
+    const e = this.requireLogin(); if (e) return e;
+    try { return await this.scripApi.scripMaster(exchangeSegment); } catch (err) { return { Error: (err as Error).message }; }
+  }
+  async searchScrip(
+    exchangeSegment: string,
+    symbol = "",
+    expiry?: string,
+    optionType?: string,
+    strikePrice?: string,
+  ): Promise<Response> {
+    const e = this.requireLogin(); if (e) return e;
+    try { return await this.scripApi.searchScrip(exchangeSegment, symbol, expiry, optionType, strikePrice); } catch (err) { return { Error: (err as Error).message }; }
+  }
+
+  // ---------- Streaming ----------
+  async subscribe(instruments: Instrument[], isIndex = false, isDepth = false): Promise<void> {
+    const e = this.requireLogin(); if (e) { console.log(e); return; }
+    this.ensureSocket();
+    await this.neoWebSocket!.getLiveFeed(instruments, isIndex, isDepth);
+  }
+  async unSubscribe(instruments: Instrument[], isIndex = false, isDepth = false): Promise<void> {
+    const e = this.requireLogin(); if (e) { console.log(e); return; }
+    this.ensureSocket();
+    await this.neoWebSocket!.unSubscribeList(instruments, isIndex, isDepth);
+  }
+  async subscribeToOrderFeed(): Promise<void> {
+    const e = this.requireLogin(); if (e) { console.log(e); return; }
+    this.ensureSocket();
+    await this.neoWebSocket!.getOrderFeed();
+  }
+
+  private ensureSocket(): void {
+    if (this.neoWebSocket) return;
+    this.neoWebSocket = new NeoWebSocket(
+      this.configuration.editSid || "",
+      this.configuration.editToken || "",
+      this.configuration.serverId || "",
+      this.configuration.dataCenter,
+    );
+    this.neoWebSocket.onOpen = (m) => this.onOpen?.(m);
+    this.neoWebSocket.onMessage = (m) => this.onMessage?.(m);
+    this.neoWebSocket.onError = (err) => this.onError?.(err);
+    this.neoWebSocket.onClose = (m) => this.onClose?.(m);
+  }
+}

--- a/client/typescript-client/src/api/loginApi.ts
+++ b/client/typescript-client/src/api/loginApi.ts
@@ -1,0 +1,65 @@
+import { Configuration } from "../configuration";
+import { RestClient, Response } from "../rest";
+import { BASE_URL, PROD_PATHS, UAT_PATHS } from "../urls";
+
+export class LoginApi {
+  constructor(private rest: RestClient, private config: Configuration) {}
+
+  async totpLogin(mobileNumber: string, ucc: string, totp: string): Promise<Response> {
+    if (!mobileNumber || !ucc || !totp) {
+      return { error: [{ message: "mobile_number, ucc or totp missing" }] };
+    }
+    const host = this.config.host.trim().toLowerCase();
+    const path = host === "prod" ? PROD_PATHS.totp_login : UAT_PATHS.totp_login;
+    const url = `${BASE_URL.replace(/\/$/, "")}/${path}`;
+    const res = await this.rest.request({
+      method: "POST",
+      url,
+      headers: {
+        Authorization: this.config.consumerKey || "",
+        "neo-fin-key": this.config.getNeoFinKey(),
+        "Content-Type": "application/json",
+      },
+      body: { mobileNumber, ucc, totp },
+    });
+    if (res.status >= 200 && res.status <= 299) {
+      const data = res.data?.data;
+      if (data) {
+        this.config.viewToken = data.token;
+        this.config.sid = data.sid;
+      }
+    }
+    return res.data;
+  }
+
+  async totpValidate(mpin: string): Promise<Response> {
+    if (!mpin) return { error: [{ message: "Mpin is missing" }] };
+    const host = this.config.host.trim().toLowerCase();
+    const path = host === "prod" ? PROD_PATHS.totp_validate : UAT_PATHS.totp_validate;
+    const url = `${BASE_URL.replace(/\/$/, "")}/${path}`;
+    const res = await this.rest.request({
+      method: "POST",
+      url,
+      headers: {
+        Authorization: this.config.consumerKey || "",
+        sid: this.config.sid || "",
+        Auth: this.config.viewToken || "",
+        "neo-fin-key": this.config.getNeoFinKey(),
+        "Content-Type": "application/json",
+      },
+      body: { mpin },
+    });
+    if (res.status >= 200 && res.status <= 299) {
+      const data = res.data?.data;
+      if (data) {
+        this.config.editToken = data.token;
+        this.config.editSid = data.sid;
+        this.config.editRid = data.rid;
+        this.config.serverId = data.hsServerId;
+        this.config.dataCenter = data.dataCenter;
+        this.config.baseUrl = data.baseUrl;
+      }
+    }
+    return res.data;
+  }
+}

--- a/client/typescript-client/src/api/marginApi.ts
+++ b/client/typescript-client/src/api/marginApi.ts
@@ -1,0 +1,42 @@
+import { Configuration } from "../configuration";
+import { RestClient, Response } from "../rest";
+import { EXCHANGE_SEGMENT, ORDER_TYPE, PRODUCT } from "../settings";
+import { MarginRequiredRequest } from "../types";
+import { validateMargin } from "../validation";
+
+export class MarginApi {
+  constructor(private rest: RestClient, private config: Configuration) {}
+
+  async marginRequired(r: MarginRequiredRequest): Promise<Response> {
+    validateMargin(r);
+    const res = await this.rest.request({
+      method: "POST",
+      url: this.config.getUrl("margin"),
+      queryParams: { sId: this.config.serverId || "" },
+      headers: {
+        Sid: this.config.editSid || "",
+        Auth: this.config.editToken || "",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: {
+        exSeg: EXCHANGE_SEGMENT[r.exchange_segment],
+        prc: r.price,
+        prcTp: ORDER_TYPE[r.order_type],
+        prod: PRODUCT[r.product],
+        qty: r.quantity,
+        tok: r.instrument_token,
+        trnsTp: r.transaction_type,
+        trgPrc: r.trigger_price,
+        brkName: r.broker_name ?? "KOTAK",
+        brnchId: r.branch_id ?? "ONLINE",
+        slAbsOrTks: r.stop_loss_type,
+        slVal: r.stop_loss_value,
+        sqrOffAbsOrTks: r.square_off_type,
+        sqrOffVal: r.square_off_value,
+        trailSL: r.trailing_stop_loss,
+        tSLTks: r.trailing_sl_value,
+      },
+    });
+    return { data: res.data };
+  }
+}

--- a/client/typescript-client/src/api/orderApi.ts
+++ b/client/typescript-client/src/api/orderApi.ts
@@ -1,4 +1,5 @@
 import { Configuration } from "../configuration";
+import { ApiValueError } from "../exceptions";
 import { RestClient, Response } from "../rest";
 import { EXCHANGE_SEGMENT, ORDER_SOURCE, ORDER_TYPE, PRODUCT } from "../settings";
 import { PlaceOrderRequest, ModifyOrderRequest } from "../types";
@@ -104,7 +105,7 @@ export class OrderApi {
   }
 
   async modifyOrder(r: ModifyOrderRequest, bookFetch: () => Promise<Response>): Promise<Response> {
-    if (!r.order_id) throw new Error("order_id is mandatory");
+    if (!r.order_id) throw new ApiValueError("order_id is mandatory");
     const body: Record<string, any> = {
       tk: r.instrument_token,
       mp: r.market_protection ?? "0",

--- a/client/typescript-client/src/api/orderApi.ts
+++ b/client/typescript-client/src/api/orderApi.ts
@@ -1,0 +1,201 @@
+import { Configuration } from "../configuration";
+import { RestClient, Response } from "../rest";
+import { EXCHANGE_SEGMENT, ORDER_SOURCE, ORDER_TYPE, PRODUCT } from "../settings";
+import { PlaceOrderRequest, ModifyOrderRequest } from "../types";
+import {
+  validatePlaceOrder,
+  validateCancelOrder,
+  validateOrderHistory,
+} from "../validation";
+
+export class OrderApi {
+  constructor(private rest: RestClient, private config: Configuration) {}
+
+  private authHeaders(contentType: string): Record<string, string> {
+    return {
+      Sid: this.config.editSid || "",
+      Auth: this.config.editToken || "",
+      "Content-Type": contentType,
+    };
+  }
+
+  private queryWithServerId(): Record<string, string> {
+    return { sId: this.config.serverId || "" };
+  }
+
+  async placeOrder(r: PlaceOrderRequest): Promise<Response> {
+    validatePlaceOrder(r);
+    const body = {
+      am: r.amo ?? "NO",
+      dq: r.disclosed_quantity ?? "0",
+      es: EXCHANGE_SEGMENT[r.exchange_segment],
+      mp: r.market_protection ?? "0",
+      pc: PRODUCT[r.product],
+      pf: r.pf ?? "N",
+      pr: r.price,
+      pt: ORDER_TYPE[r.order_type],
+      qt: r.quantity,
+      rt: r.validity,
+      tp: r.trigger_price ?? "0",
+      ts: r.trading_symbol,
+      tt: r.transaction_type,
+      ig: r.tag,
+      tk: r.scrip_token,
+      sot: r.square_off_type,
+      slt: r.stop_loss_type,
+      slv: r.stop_loss_value,
+      sov: r.square_off_value,
+      lat: r.last_traded_price,
+      tlt: r.trailing_stop_loss,
+      tsv: r.trailing_sl_value,
+      os: ORDER_SOURCE,
+    };
+    const res = await this.rest.request({
+      method: "POST",
+      url: this.config.getUrl("place_order"),
+      queryParams: this.queryWithServerId(),
+      headers: this.authHeaders("application/x-www-form-urlencoded"),
+      body,
+    });
+    return res.data;
+  }
+
+  async cancelOrder(orderId: string, amo = "NO", verify = false, bookFetch?: () => Promise<Response>): Promise<Response> {
+    return this.cancelEndpoint("cancel_order", orderId, amo, verify, bookFetch);
+  }
+
+  async cancelCoverOrder(orderId: string, amo = "NO", verify = false, bookFetch?: () => Promise<Response>): Promise<Response> {
+    return this.cancelEndpoint("cancel_cover_order", orderId, amo, verify, bookFetch);
+  }
+
+  async cancelBracketOrder(orderId: string, amo = "NO", verify = false, bookFetch?: () => Promise<Response>): Promise<Response> {
+    return this.cancelEndpoint("cancel_bracket_order", orderId, amo, verify, bookFetch);
+  }
+
+  private async cancelEndpoint(
+    endpoint: string,
+    orderId: string,
+    amo: string,
+    verify: boolean,
+    bookFetch?: () => Promise<Response>,
+  ): Promise<Response> {
+    validateCancelOrder(orderId);
+    if (verify && bookFetch) {
+      const book = await bookFetch();
+      if (Array.isArray(book?.data)) {
+        for (const row of book.data as any[]) {
+          if (row.nOrdNo === orderId) {
+            if (["rejected", "cancelled", "complete", "traded"].includes(row.ordSt)) {
+              const st = row.ordSt === "complete" ? "Traded" : row.ordSt;
+              return { Error: `The Given Order Status is ${st}`, Reason: row.rejRsn };
+            }
+          }
+        }
+      }
+    }
+    const res = await this.rest.request({
+      method: "POST",
+      url: this.config.getUrl(endpoint),
+      queryParams: this.queryWithServerId(),
+      headers: this.authHeaders("application/x-www-form-urlencoded"),
+      body: { on: orderId, am: amo },
+    });
+    return res.data;
+  }
+
+  async modifyOrder(r: ModifyOrderRequest, bookFetch: () => Promise<Response>): Promise<Response> {
+    if (!r.order_id) throw new Error("order_id is mandatory");
+    const body: Record<string, any> = {
+      tk: r.instrument_token,
+      mp: r.market_protection ?? "0",
+      pc: r.product,
+      dd: r.dd ?? "NA",
+      dq: r.disclosed_quantity ?? "0",
+      vd: r.validity,
+      ts: r.trading_symbol,
+      tt: r.transaction_type,
+      pr: r.price,
+      pt: r.order_type,
+      fq: r.filled_quantity ?? "0",
+      tp: r.trigger_price ?? "0",
+      qt: r.quantity,
+      no: r.order_id,
+      es: r.exchange_segment,
+      am: r.amo ?? "NO",
+      os: ORDER_SOURCE,
+    };
+
+    const hasAll = !!(r.instrument_token && r.exchange_segment && r.trading_symbol && r.product);
+    if (hasAll) {
+      body.es = EXCHANGE_SEGMENT[r.exchange_segment!];
+      body.pc = PRODUCT[r.product!];
+      body.pt = ORDER_TYPE[r.order_type];
+    } else {
+      // hydrate from order book
+      const book = await bookFetch();
+      if (!Array.isArray(book?.data)) return { Message: "There is no Data in the Order Book" };
+      const row = (book.data as any[]).find((it) => it.nOrdNo === r.order_id);
+      if (!row) return { Message: `The Given Order Number ${r.order_id} is not matching with any of the orders` };
+      if (["rejected", "cancelled", "complete", "traded"].includes(row.ordSt)) {
+        const st = row.ordSt === "complete" ? "Traded" : row.ordSt;
+        return {
+          Error: `The Given Order Status is ${st}, So we can't proceed further`,
+          Reason: row.rejRsn,
+        };
+      }
+      body.ts = r.trading_symbol ?? row.trdSym;
+      body.tk = r.instrument_token ?? row.tok;
+      body.pc = r.product ?? row.prod;
+      body.tt = r.transaction_type ?? row.trnsTp;
+      body.es = r.exchange_segment ?? row.exSeg;
+      if ((r.trigger_price ?? "0") === "0") body.tp = row.trgPrc;
+    }
+
+    const res = await this.rest.request({
+      method: "POST",
+      url: this.config.getUrl("modify_order"),
+      queryParams: this.queryWithServerId(),
+      headers: this.authHeaders("application/x-www-form-urlencoded"),
+      body,
+    });
+    return res.data;
+  }
+
+  async orderReport(): Promise<Response> {
+    const res = await this.rest.request({
+      method: "GET",
+      url: this.config.getUrl("order_book"),
+      queryParams: this.queryWithServerId(),
+      headers: { ...this.authHeaders("application/x-www-form-urlencoded"), accept: "application/json" },
+    });
+    return res.data;
+  }
+
+  async orderHistory(orderId: string): Promise<Response> {
+    validateOrderHistory(orderId);
+    const res = await this.rest.request({
+      method: "POST",
+      url: this.config.getUrl("order_history"),
+      queryParams: this.queryWithServerId(),
+      headers: this.authHeaders("application/x-www-form-urlencoded"),
+      body: { nOrdNo: orderId },
+    });
+    return res.data;
+  }
+
+  async tradeReport(orderId?: string): Promise<Response> {
+    const res = await this.rest.request({
+      method: "GET",
+      url: this.config.getUrl("trade_report"),
+      queryParams: this.queryWithServerId(),
+      headers: { ...this.authHeaders("application/x-www-form-urlencoded"), accept: "application/json" },
+    });
+    const data = res.data;
+    if (!orderId) return data;
+    if (!Array.isArray(data?.data))
+      return { Error: "There is no trades available with the given order id" };
+    const match = (data.data as any[]).find((it) => it.nOrdNo === orderId);
+    if (!match) return { Error: "There is no trades available with the given order id" };
+    return { stat: data.stat, stCode: data.stCode, data: match };
+  }
+}

--- a/client/typescript-client/src/api/portfolioApi.ts
+++ b/client/typescript-client/src/api/portfolioApi.ts
@@ -1,0 +1,50 @@
+import { Configuration } from "../configuration";
+import { RestClient, Response } from "../rest";
+import { validateLimits } from "../validation";
+
+export class PortfolioApi {
+  constructor(private rest: RestClient, private config: Configuration) {}
+
+  private authHeaders(contentType: string): Record<string, string> {
+    return {
+      Sid: this.config.editSid || "",
+      Auth: this.config.editToken || "",
+      "Content-Type": contentType,
+    };
+  }
+  private serverId(): Record<string, string> {
+    return { sId: this.config.serverId || "" };
+  }
+
+  async positions(): Promise<Response> {
+    const res = await this.rest.request({
+      method: "GET",
+      url: this.config.getUrl("positions"),
+      queryParams: this.serverId(),
+      headers: { ...this.authHeaders("application/x-www-form-urlencoded"), accept: "application/json" },
+    });
+    return res.data;
+  }
+
+  async holdings(): Promise<Response> {
+    const res = await this.rest.request({
+      method: "GET",
+      url: this.config.getUrl("holdings"),
+      queryParams: this.serverId(),
+      headers: { ...this.authHeaders("application/x-www-form-urlencoded"), accept: "*/*" },
+    });
+    return res.data;
+  }
+
+  async limits(segment = "ALL", exchange = "ALL", product = "ALL"): Promise<Response> {
+    validateLimits(segment, exchange, product);
+    const res = await this.rest.request({
+      method: "POST",
+      url: this.config.getUrl("limits"),
+      queryParams: this.serverId(),
+      headers: this.authHeaders("application/x-www-form-urlencoded"),
+      body: { seg: segment, exch: exchange, prod: product },
+    });
+    return res.data;
+  }
+}

--- a/client/typescript-client/src/api/quotesApi.ts
+++ b/client/typescript-client/src/api/quotesApi.ts
@@ -1,0 +1,30 @@
+import { Configuration } from "../configuration";
+import { RestClient, Response } from "../rest";
+import { QuoteInstrument } from "../types";
+
+export class QuotesApi {
+  constructor(private rest: RestClient, private config: Configuration) {}
+
+  async quotes(instruments: QuoteInstrument[], quoteType?: string): Promise<Response> {
+    if (!instruments || instruments.length === 0) {
+      return { error: [{ message: "Validation Errors! instrument_tokens are missing" }] };
+    }
+    const qt = quoteType || "all";
+    const parts = instruments
+      .map((i) => `${i.exchange_segment}|${i.instrument_token}`)
+      .join(",");
+    const raw = this.config.getUrl("quotes_neo_symbol");
+    const url = raw
+      .replace("{neo_symbols}", encodeURIComponent(parts))
+      .replace("{quote_type}", qt);
+    const res = await this.rest.request({
+      method: "GET",
+      url,
+      headers: {
+        Authorization: this.config.consumerKey || "",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    });
+    return res.data;
+  }
+}

--- a/client/typescript-client/src/api/scripApi.ts
+++ b/client/typescript-client/src/api/scripApi.ts
@@ -1,0 +1,59 @@
+import { Configuration } from "../configuration";
+import { RestClient, Response } from "../rest";
+import { EXCHANGE_SEGMENT } from "../settings";
+
+export class ScripApi {
+  constructor(private rest: RestClient, private config: Configuration) {}
+
+  async scripMaster(exchangeSegment?: string): Promise<Response> {
+    const res = await this.rest.request({
+      method: "GET",
+      url: this.config.getUrl("scrip_master"),
+      headers: {
+        Authorization: this.config.consumerKey || "",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    });
+    if (res.status !== 200) return res.data;
+    const data = res.data?.data;
+    if (!data) return res.data;
+    if (!exchangeSegment) return data;
+    const seg = EXCHANGE_SEGMENT[exchangeSegment];
+    if (!seg) return { Error: "Exchange segment not found" };
+    const match = (data.filesPaths as string[] | undefined)?.find((p) =>
+      p.toLowerCase().includes(seg.toLowerCase()),
+    );
+    if (!match) return { Error: "Exchange segment not found" };
+    return { path: match };
+  }
+
+  async searchScrip(
+    exchangeSegment: string,
+    symbol = "",
+    expiry?: string,
+    optionType?: string,
+    strikePrice?: string,
+  ): Promise<Response> {
+    if (!exchangeSegment) {
+      return {
+        error: [
+          {
+            code: "10300",
+            message: "Validation Errors! Exchange Segment is Mandate to proceed further",
+          },
+        ],
+      };
+    }
+    const master = await this.scripMaster(exchangeSegment);
+    if (!master.path) return { Error: "Exchange Segment is not available" };
+    return {
+      exchange_segment: exchangeSegment,
+      symbol: symbol.toLowerCase(),
+      expiry,
+      option_type: optionType,
+      strike_price: strikePrice,
+      csv_url: master.path,
+      hint: "Download csv_url and filter client-side by symbol/expiry/strike",
+    };
+  }
+}

--- a/client/typescript-client/src/configuration.ts
+++ b/client/typescript-client/src/configuration.ts
@@ -1,0 +1,63 @@
+import { ApiValueError, ApiKeyError } from "./exceptions";
+import { PROD_BASE_URL, UAT_BASE_URL, BASE_URL, PROD_PATHS, UAT_PATHS } from "./urls";
+
+export class Configuration {
+  host: string;
+  bearerToken?: string;
+  viewToken?: string;
+  sid?: string;
+  userId?: string;
+  editToken?: string;
+  editSid?: string;
+  editRid?: string;
+  serverId?: string;
+  neoFinKey?: string;
+  dataCenter?: string;
+  baseUrl?: string;
+  totpSessionId?: string;
+  consumerKey?: string;
+
+  constructor(host: string = "uat") {
+    this.host = host;
+  }
+
+  isLoggedIn(): boolean {
+    return !!(this.editToken && this.editSid);
+  }
+
+  extractUserId(viewToken: string): string {
+    if (!viewToken) throw new ApiValueError("view_token is empty — call totp_login first");
+    const parts = viewToken.split(".");
+    if (parts.length < 2) throw new ApiValueError("invalid JWT");
+    const payload = Buffer.from(parts[1], "base64url").toString("utf8");
+    const claims = JSON.parse(payload);
+    if (!claims.sub) throw new ApiKeyError("sub claim missing from token");
+    this.userId = claims.sub;
+    return claims.sub;
+  }
+
+  getDomain(sessionInit: boolean = false): string {
+    const host = this.host.trim().toLowerCase();
+    if (host !== "prod" && host !== "uat") {
+      throw new ApiValueError("environment must be 'prod' or 'uat'");
+    }
+    if (sessionInit) return BASE_URL;
+    if (host === "prod") return this.baseUrl || PROD_BASE_URL;
+    return UAT_BASE_URL;
+  }
+
+  getUrl(apiInfo: string): string {
+    const host = this.host.trim().toLowerCase();
+    const domain = this.getDomain(false).replace(/\/$/, "");
+    const path = host === "prod" ? PROD_PATHS[apiInfo] : UAT_PATHS[apiInfo];
+    if (!path) throw new ApiValueError(`unknown endpoint: ${apiInfo}`);
+    return `${domain}/${path}`;
+  }
+
+  getNeoFinKey(): string {
+    if (this.neoFinKey) return this.neoFinKey;
+    return this.host.trim().toLowerCase() === "prod"
+      ? "neotradeapi"
+      : "bQJNkL5z8m4aGcRgjDvXhHfSx7VpZnE";
+  }
+}

--- a/client/typescript-client/src/exceptions.ts
+++ b/client/typescript-client/src/exceptions.ts
@@ -1,0 +1,24 @@
+export class OpenApiError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+export class ApiTypeError extends OpenApiError {}
+export class ApiValueError extends OpenApiError {}
+export class ApiAttributeError extends OpenApiError {}
+export class ApiKeyError extends OpenApiError {}
+
+export class ApiException extends OpenApiError {
+  status: number;
+  reason: string;
+  body: string | undefined;
+
+  constructor(status: number, reason: string, body?: string) {
+    super(`(${status}) ${reason}${body ? `: ${body}` : ""}`);
+    this.status = status;
+    this.reason = reason;
+    this.body = body;
+  }
+}

--- a/client/typescript-client/src/index.ts
+++ b/client/typescript-client/src/index.ts
@@ -1,0 +1,7 @@
+export { NeoAPI } from "./NeoAPI";
+export { Configuration } from "./configuration";
+export { NeoWebSocket } from "./websocket/NeoWebSocket";
+export * from "./exceptions";
+export * from "./types";
+export * as settings from "./settings";
+export * as urls from "./urls";

--- a/client/typescript-client/src/rest.ts
+++ b/client/typescript-client/src/rest.ts
@@ -1,0 +1,52 @@
+import { Configuration } from "./configuration";
+import { ApiException } from "./exceptions";
+
+export type Response = Record<string, any>;
+
+export interface RestRequestOptions {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  url: string;
+  queryParams?: Record<string, string>;
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+export class RestClient {
+  constructor(public config: Configuration) {}
+
+  async request(opts: RestRequestOptions): Promise<{ status: number; data: any; text: string }> {
+    const headers: Record<string, string> = { ...(opts.headers || {}) };
+    if (!headers["Content-Type"]) headers["Content-Type"] = "application/json";
+    headers["User-Agent"] = headers["User-Agent"] || "NeoTradeApi-ts/1.0.0";
+
+    let url = opts.url;
+    if (opts.queryParams && Object.keys(opts.queryParams).length > 0) {
+      const params = new URLSearchParams(opts.queryParams).toString();
+      url += (url.includes("?") ? "&" : "?") + params;
+    }
+
+    let body: string | undefined;
+    if (["POST", "PUT", "PATCH", "DELETE"].includes(opts.method)) {
+      const ct = headers["Content-Type"].toLowerCase();
+      if (ct.includes("json")) {
+        body = opts.body !== undefined ? JSON.stringify(opts.body) : undefined;
+      } else if (ct.includes("x-www-form-urlencoded")) {
+        const form = new URLSearchParams();
+        if (opts.body !== undefined) form.set("jData", JSON.stringify(opts.body));
+        body = form.toString();
+      } else {
+        throw new ApiException(0, "Invalid Content-Type", ct);
+      }
+    }
+
+    const res = await fetch(url, { method: opts.method, headers, body });
+    const text = await res.text();
+    let data: any;
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      data = { raw: text };
+    }
+    return { status: res.status, data, text };
+  }
+}

--- a/client/typescript-client/src/settings.ts
+++ b/client/typescript-client/src/settings.ts
@@ -1,0 +1,78 @@
+export const EXCHANGE_SEGMENT: Record<string, string> = {
+  nse_cm: "nse_cm", NSE: "nse_cm", nse: "nse_cm",
+  BSE: "bse_cm", bse: "bse_cm", bse_cm: "bse_cm",
+  NFO: "nse_fo", nse_fo: "nse_fo", nfo: "nse_fo",
+  BFO: "bse_fo", bse_fo: "bse_fo", bfo: "bse_fo",
+  CDS: "cde_fo", cde_fo: "cde_fo", cds: "cde_fo",
+  BCD: "bcs-fo", "bcs-fo": "bcs-fo", bcd: "bcs-fo",
+  MCX: "mcx_fo", mcx: "mcx_fo", mcx_fo: "mcx_fo",
+};
+
+export const PRODUCT: Record<string, string> = {
+  Normal: "NRML", NRML: "NRML",
+  CNC: "CNC", cnc: "CNC", "Cash and Carry": "CNC",
+  MIS: "MIS", mis: "MIS",
+  INTRADAY: "INTRADAY", intraday: "INTRADAY",
+  "Cover Order": "CO", co: "CO", CO: "CO",
+  BO: "BO", "Bracket Order": "BO", bo: "BO",
+  mtf: "MTF", MTF: "MTF",
+};
+
+export const ORDER_TYPE: Record<string, string> = {
+  Limit: "L", L: "L", l: "L",
+  MKT: "MKT", mkt: "MKT", Market: "MKT",
+  sl: "SL", SL: "SL", "Stop loss limit": "SL",
+  "Stop loss market": "SL-M", "SL-M": "SL-M", "sl-m": "SL-M",
+  Spread: "SP", SP: "SP", sp: "SP",
+  "2L": "2L", "2l": "2L", "Two Leg": "2L",
+  "3L": "3L", "3l": "3L", "Three leg": "3L",
+};
+
+export const SEGMENT_LIMITS = ["CASH", "CUR", "FO", "ALL"];
+export const EXCHANGE_LIMITS = ["NSE", "BSE", "ALL"];
+export const PRODUCT_LIMITS = ["CNC", "MIS", "NRML", "ALL"];
+
+export const REQ_TYPE_VALUES: Record<string, string> = {
+  CONNECTION: "cn",
+  SCRIP_SUBS: "mws",
+  SCRIP_UNSUBS: "mwu",
+  INDEX_SUBS: "ifs",
+  INDEX_UNSUBS: "ifu",
+  DEPTH_SUBS: "dps",
+  DEPTH_UNSUBS: "dpu",
+  CHANNEL_RESUME: "cr",
+  CHANNEL_PAUSE: "cp",
+  SNAP_MW: "mwsp",
+  SNAP_DP: "dpsp",
+  SNAP_IF: "ifsp",
+  OPC_SUBS: "opc",
+  THROTTLING_INTERVAL: "ti",
+  STR: "str",
+  FORCE_CONNECTION: "fcn",
+};
+
+export const STOCK_KEY_MAPPING: Record<string, string> = {
+  ltt: "last_traded_time", v: "volume", ltp: "last_traded_price",
+  ltq: "last_traded_quantity", tbq: "total_buy_quantity",
+  tsq: "total_sell_quantity", bp: "buy_price", sp: "sell_price",
+  bq: "buy_quantity", sq: "sell_quantity", ap: "average_price",
+  oi: "open_interest", lo: "low", h: "high",
+  lcl: "lower_circuit_limit", ucl: "upper_circuit_limit",
+  yh: "52week_high", yl: "52week_low", op: "open", c: "close",
+  mul: "multiplier", prec: "precision", cng: "change",
+  nc: "net_change_percentage", to: "total_traded_value",
+  tk: "instrument_token", e: "exchange_segment", ts: "trading_symbol",
+  request_type: "request_type",
+};
+
+export const INDEX_KEY_MAPPING: Record<string, string> = {
+  iv: "last_traded_price", ic: "prev_day_close",
+  tvalue: "timestamp", highPrice: "high_price",
+  lowPrice: "low_price", openingPrice: "open",
+  mul: "multiplier", prec: "precision",
+  cng: "change", nc: "net_change_percentage",
+  tk: "instrument_token", e: "exchange_segment",
+};
+
+export const ORDER_SOURCE = "NEOTRADEAPI";
+export const QUOTES_CHANNEL = 1;

--- a/client/typescript-client/src/types.ts
+++ b/client/typescript-client/src/types.ts
@@ -1,0 +1,73 @@
+export interface PlaceOrderRequest {
+  exchange_segment: string;
+  product: string;
+  price: string;
+  order_type: string;
+  quantity: string;
+  validity: string;
+  trading_symbol: string;
+  transaction_type: string;
+  amo?: string;
+  disclosed_quantity?: string;
+  market_protection?: string;
+  pf?: string;
+  trigger_price?: string;
+  tag?: string;
+  scrip_token?: string;
+  square_off_type?: string;
+  stop_loss_type?: string;
+  stop_loss_value?: string;
+  square_off_value?: string;
+  last_traded_price?: string;
+  trailing_stop_loss?: string;
+  trailing_sl_value?: string;
+}
+
+export interface ModifyOrderRequest {
+  order_id: string;
+  price: string;
+  order_type: string;
+  quantity: string;
+  validity: string;
+  instrument_token?: string;
+  exchange_segment?: string;
+  product?: string;
+  trading_symbol?: string;
+  transaction_type?: string;
+  trigger_price?: string;
+  dd?: string;
+  market_protection?: string;
+  disclosed_quantity?: string;
+  filled_quantity?: string;
+  amo?: string;
+}
+
+export interface MarginRequiredRequest {
+  exchange_segment: string;
+  price: string;
+  order_type: string;
+  product: string;
+  quantity: string;
+  instrument_token: string;
+  transaction_type: string;
+  trigger_price?: string;
+  broker_name?: string;
+  branch_id?: string;
+  stop_loss_type?: string;
+  stop_loss_value?: string;
+  square_off_type?: string;
+  square_off_value?: string;
+  trailing_stop_loss?: string;
+  trailing_sl_value?: string;
+}
+
+export interface Instrument {
+  instrument_token: string;
+  exchange_segment: string;
+}
+
+export interface QuoteInstrument extends Instrument {}
+
+export type MessageCallback = (msg: any) => void;
+export type ErrorCallback = (err: unknown) => void;
+export type VoidCallback = (msg?: string) => void;

--- a/client/typescript-client/src/urls.ts
+++ b/client/typescript-client/src/urls.ts
@@ -1,0 +1,51 @@
+export const WEBSOCKET_URL = "wss://mlhsm.kotaksecurities.com";
+
+export const ORDER_FEED_URL = "wss://mis.kotaksecurities.com/realtime";
+export const ORDER_FEED_URL_ADC = "wss://cis.kotaksecurities.com/realtime";
+export const ORDER_FEED_URL_E21 = "wss://e21.kotaksecurities.com/realtime";
+export const ORDER_FEED_URL_E22 = "wss://e22.kotaksecurities.com/realtime";
+export const ORDER_FEED_URL_E41 = "wss://e41.kotaksecurities.com/realtime";
+export const ORDER_FEED_URL_E43 = "wss://e43.kotaksecurities.com/realtime";
+
+export const BASE_URL = "https://mis.kotaksecurities.com";
+
+export const UAT_BASE_URL = "https://nsbxapi-gw.kotaksecurities.com/";
+export const PROD_BASE_URL = "https://mnapi.kotaksecurities.com/";
+
+export const UAT_PATHS: Record<string, string> = {
+  totp_login: "api/1.0/login/v6/totp/login",
+  totp_validate: "api/1.0/login/v6/totp/validate",
+  place_order: "orderapi/1.0/quick/order/rule/ms/place",
+  cancel_order: "orderapi/1.0/quick/order/cancel",
+  modify_order: "orderapi/1.0/quick/order/vr/modify",
+  order_history: "orderapi/1.0/quick/order/history",
+  order_book: "orderapi/1.0/quick/user/orders",
+  trade_report: "orderapi/1.0/quick/user/trades",
+  positions: "orderapi/1.0/quick/user/positions",
+  holdings: "portfolio/1.0/portfolio/v1/holdings",
+  margin: "orderapi/1.0/quick/user/check-margin",
+  scrip_master: "scrip/1.0/masterscrip/file-paths",
+  limits: "orderapi/1.0/quick/user/limits",
+  logout: "api/1.0/logout",
+  quotes_neo_symbol: "script-details/1.0/quotes/neosymbol/{neo_symbols}/{quote_type}",
+};
+
+export const PROD_PATHS: Record<string, string> = {
+  totp_login: "login/1.0/tradeApiLogin",
+  totp_validate: "login/1.0/tradeApiValidate",
+  place_order: "quick/order/rule/ms/place",
+  cancel_order: "quick/order/cancel",
+  cancel_cover_order: "quick/order/co/exit",
+  cancel_bracket_order: "quick/order/bo/exit",
+  modify_order: "quick/order/vr/modify",
+  order_history: "quick/order/history",
+  order_book: "quick/user/orders",
+  trade_report: "quick/user/trades",
+  positions: "quick/user/positions",
+  holdings: "portfolio/v1/holdings",
+  margin: "quick/user/check-margin",
+  scrip_master: "script-details/1.0/masterscrip/file-paths",
+  limits: "quick/user/limits",
+  logout: "apim/login/2.0/logout",
+  quotes_neo_symbol: "/script-details/1.0/quotes/neosymbol/{neo_symbols}/{quote_type}",
+};

--- a/client/typescript-client/src/validation.ts
+++ b/client/typescript-client/src/validation.ts
@@ -1,0 +1,67 @@
+import { ApiValueError } from "./exceptions";
+import {
+  EXCHANGE_SEGMENT,
+  PRODUCT,
+  ORDER_TYPE,
+  SEGMENT_LIMITS,
+  EXCHANGE_LIMITS,
+  PRODUCT_LIMITS,
+} from "./settings";
+
+function nonEmpty(val: unknown, name: string): void {
+  if (val === undefined || val === null || String(val).trim() === "") {
+    throw new ApiValueError(`${name} is mandatory`);
+  }
+}
+
+export function validatePlaceOrder(p: {
+  exchange_segment: string;
+  product: string;
+  price: string;
+  order_type: string;
+  quantity: string;
+  validity: string;
+  trading_symbol: string;
+  transaction_type: string;
+}): void {
+  Object.entries(p).forEach(([k, v]) => nonEmpty(v, k));
+  if (!(p.exchange_segment in EXCHANGE_SEGMENT))
+    throw new ApiValueError(`invalid exchange_segment: ${p.exchange_segment}`);
+  if (!(p.product in PRODUCT)) throw new ApiValueError(`invalid product: ${p.product}`);
+  if (!(p.order_type in ORDER_TYPE))
+    throw new ApiValueError(`invalid order_type: ${p.order_type}`);
+  const tt = p.transaction_type.toUpperCase();
+  if (!["B", "S", "BUY", "SELL"].includes(tt))
+    throw new ApiValueError("transaction_type must be B/S");
+}
+
+export function validateCancelOrder(orderId: string): void {
+  nonEmpty(orderId, "order_id");
+}
+
+export function validateOrderHistory(orderId: string): void {
+  nonEmpty(orderId, "order_id");
+}
+
+export function validateMargin(p: {
+  exchange_segment: string;
+  price: string;
+  order_type: string;
+  product: string;
+  quantity: string;
+  instrument_token: string;
+  transaction_type: string;
+}): void {
+  Object.entries(p).forEach(([k, v]) => nonEmpty(v, k));
+  if (!(p.exchange_segment in EXCHANGE_SEGMENT))
+    throw new ApiValueError(`invalid exchange_segment: ${p.exchange_segment}`);
+}
+
+export function validateLimits(segment: string, exchange: string, product: string): void {
+  if (!SEGMENT_LIMITS.includes(segment))
+    throw new ApiValueError(`invalid segment: ${segment}`);
+  if (!EXCHANGE_LIMITS.includes(exchange))
+    throw new ApiValueError(`invalid exchange: ${exchange}`);
+  if (!PRODUCT_LIMITS.includes(product))
+    throw new ApiValueError(`invalid product: ${product}`);
+}

--- a/client/typescript-client/src/validation.ts
+++ b/client/typescript-client/src/validation.ts
@@ -14,6 +14,10 @@ function nonEmpty(val: unknown, name: string): void {
   }
 }
 
+const VALIDITY_VALUES = ["DAY", "IOC"];
+const PLACE_ORDER_TT = ["B", "S", "Buy", "Sell"];
+const MARGIN_TT = ["B", "S", "Buy", "Sell", "sell", "buy"];
+
 export function validatePlaceOrder(p: {
   exchange_segment: string;
   product: string;
@@ -30,9 +34,10 @@ export function validatePlaceOrder(p: {
   if (!(p.product in PRODUCT)) throw new ApiValueError(`invalid product: ${p.product}`);
   if (!(p.order_type in ORDER_TYPE))
     throw new ApiValueError(`invalid order_type: ${p.order_type}`);
-  const tt = p.transaction_type.toUpperCase();
-  if (!["B", "S", "BUY", "SELL"].includes(tt))
-    throw new ApiValueError("transaction_type must be B/S");
+  if (!VALIDITY_VALUES.includes(p.validity))
+    throw new ApiValueError("Invalid validity. Allowed values are DAY, IOC.");
+  if (!PLACE_ORDER_TT.includes(p.transaction_type))
+    throw new ApiValueError("Invalid transaction type. Allowed values are B or Buy, S or Sell.");
 }
 
 export function validateCancelOrder(orderId: string): void {
@@ -55,6 +60,12 @@ export function validateMargin(p: {
   Object.entries(p).forEach(([k, v]) => nonEmpty(v, k));
   if (!(p.exchange_segment in EXCHANGE_SEGMENT))
     throw new ApiValueError(`invalid exchange_segment: ${p.exchange_segment}`);
+  if (!(p.product in PRODUCT))
+    throw new ApiValueError(`invalid product: ${p.product}`);
+  if (!(p.order_type in ORDER_TYPE))
+    throw new ApiValueError(`invalid order_type: ${p.order_type}`);
+  if (!MARGIN_TT.includes(p.transaction_type))
+    throw new ApiValueError("Invalid transaction type. Allowed values are B or Buy, S or Sell.");
 }
 
 export function validateLimits(segment: string, exchange: string, product: string): void {

--- a/client/typescript-client/src/websocket/NeoWebSocket.ts
+++ b/client/typescript-client/src/websocket/NeoWebSocket.ts
@@ -1,0 +1,180 @@
+import WebSocket from "ws";
+import {
+  WEBSOCKET_URL,
+  ORDER_FEED_URL,
+  ORDER_FEED_URL_ADC,
+  ORDER_FEED_URL_E21,
+  ORDER_FEED_URL_E22,
+  ORDER_FEED_URL_E41,
+  ORDER_FEED_URL_E43,
+} from "../urls";
+import { REQ_TYPE_VALUES } from "../settings";
+import { Instrument, MessageCallback, ErrorCallback, VoidCallback } from "../types";
+import { decodeBinaryFrame } from "./hsWebSocketCodec";
+
+/**
+ * NeoWebSocket manages the market-data and order-feed WebSocket connections.
+ * Mirrors the Python NeoWebSocket class.
+ */
+export class NeoWebSocket {
+  private marketSocket?: WebSocket;
+  private orderSocket?: WebSocket;
+  private marketOpen = false;
+  private orderOpen = false;
+  private marketHeartbeatTimer?: NodeJS.Timeout;
+  private orderHeartbeatTimer?: NodeJS.Timeout;
+
+  onOpen?: VoidCallback;
+  onMessage?: MessageCallback;
+  onError?: ErrorCallback;
+  onClose?: VoidCallback;
+
+  constructor(
+    private sid: string,
+    private token: string,
+    private serverId: string,
+    private dataCenter: string | undefined,
+  ) {}
+
+  async getLiveFeed(instruments: Instrument[], isIndex = false, isDepth = false): Promise<void> {
+    let subType = REQ_TYPE_VALUES.SCRIP_SUBS;
+    if (isIndex) subType = REQ_TYPE_VALUES.INDEX_SUBS;
+    if (isDepth) subType = REQ_TYPE_VALUES.DEPTH_SUBS;
+
+    if (!this.marketOpen) await this.openMarket();
+    const scrips = instruments
+      .map((i) => `${i.exchange_segment}|${i.instrument_token}`)
+      .join("&");
+    this.sendMarket({ type: subType, scrips, channelnum: 2 });
+  }
+
+  async unSubscribeList(instruments: Instrument[], isIndex = false, isDepth = false): Promise<void> {
+    let unsub = REQ_TYPE_VALUES.SCRIP_UNSUBS;
+    if (isIndex) unsub = REQ_TYPE_VALUES.INDEX_UNSUBS;
+    if (isDepth) unsub = REQ_TYPE_VALUES.DEPTH_UNSUBS;
+    const scrips = instruments
+      .map((i) => `${i.exchange_segment}|${i.instrument_token}`)
+      .join("&");
+    this.sendMarket({ type: unsub, scrips, channelnum: 2 });
+  }
+
+  async getOrderFeed(): Promise<void> {
+    if (this.orderOpen) return;
+    await this.openOrder();
+  }
+
+  close(): void {
+    this.marketOpen = false;
+    this.orderOpen = false;
+    if (this.marketHeartbeatTimer) clearInterval(this.marketHeartbeatTimer);
+    if (this.orderHeartbeatTimer) clearInterval(this.orderHeartbeatTimer);
+    this.marketSocket?.close();
+    this.orderSocket?.close();
+  }
+
+  private openMarket(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(WEBSOCKET_URL);
+      this.marketSocket = ws;
+      ws.on("open", () => {
+        this.marketOpen = true;
+        ws.send(JSON.stringify({ type: "cn", Authorization: this.token, Sid: this.sid }));
+        this.marketHeartbeatTimer = setInterval(() => {
+          if (this.marketOpen) ws.send(JSON.stringify({ type: "hb" }));
+        }, 29_000);
+        this.onOpen?.("market socket opened");
+        resolve();
+      });
+      ws.on("message", (data) => this.handleMarketMessage(data as Buffer));
+      ws.on("error", (err) => {
+        this.marketOpen = false;
+        this.onError?.(err);
+        reject(err);
+      });
+      ws.on("close", () => {
+        this.marketOpen = false;
+        if (this.marketHeartbeatTimer) clearInterval(this.marketHeartbeatTimer);
+        this.onClose?.("market socket closed");
+      });
+    });
+  }
+
+  private openOrder(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let url = ORDER_FEED_URL;
+      switch ((this.dataCenter || "").toLowerCase()) {
+        case "adc": url = ORDER_FEED_URL_ADC; break;
+        case "e21": url = ORDER_FEED_URL_E21; break;
+        case "e22": url = ORDER_FEED_URL_E22; break;
+        case "e41": url = ORDER_FEED_URL_E41; break;
+        case "e43": url = ORDER_FEED_URL_E43; break;
+      }
+      const ws = new WebSocket(url);
+      this.orderSocket = ws;
+      ws.on("open", () => {
+        this.orderOpen = true;
+        ws.send(JSON.stringify({
+          type: "CONNECTION", Authorization: this.token, Sid: this.sid, source: "WEB",
+        }));
+        this.orderHeartbeatTimer = setInterval(() => {
+          if (this.orderOpen) ws.send(JSON.stringify({ type: "HB" }));
+        }, 30_000);
+        this.onOpen?.("order feed opened");
+        resolve();
+      });
+      ws.on("message", (data) => this.handleOrderMessage(data as Buffer));
+      ws.on("error", (err) => {
+        this.orderOpen = false;
+        this.onError?.(err);
+        reject(err);
+      });
+      ws.on("close", () => {
+        this.orderOpen = false;
+        if (this.orderHeartbeatTimer) clearInterval(this.orderHeartbeatTimer);
+        this.onClose?.("order feed closed");
+      });
+    });
+  }
+
+  private sendMarket(payload: unknown): void {
+    if (!this.marketSocket || this.marketSocket.readyState !== WebSocket.OPEN) return;
+    this.marketSocket.send(JSON.stringify(payload));
+  }
+
+  private handleMarketMessage(data: Buffer | string): void {
+    if (typeof data === "string") {
+      try {
+        const parsed = JSON.parse(data);
+        this.onMessage?.({ type: "stock_feed", data: parsed });
+      } catch {
+        this.onMessage?.({ type: "stock_feed", data });
+      }
+      return;
+    }
+    // Binary frame — attempt text first, fall back to binary codec.
+    const txt = data.toString("utf8");
+    if (txt.startsWith("[") || txt.startsWith("{")) {
+      try {
+        this.onMessage?.({ type: "stock_feed", data: JSON.parse(txt) });
+        return;
+      } catch {
+        /* fall through */
+      }
+    }
+    try {
+      const frames = decodeBinaryFrame(data);
+      this.onMessage?.({ type: "stock_feed", data: frames });
+    } catch (err) {
+      this.onError?.(err);
+    }
+  }
+
+  private handleOrderMessage(data: Buffer | string): void {
+    const txt = typeof data === "string" ? data : data.toString("utf8");
+    try {
+      this.onMessage?.({ type: "order_feed", data: JSON.parse(txt) });
+    } catch {
+      this.onMessage?.({ type: "order_feed", data: txt });
+    }
+  }
+}

--- a/client/typescript-client/src/websocket/NeoWebSocket.ts
+++ b/client/typescript-client/src/websocket/NeoWebSocket.ts
@@ -12,6 +12,14 @@ import { REQ_TYPE_VALUES } from "../settings";
 import { Instrument, MessageCallback, ErrorCallback, VoidCallback } from "../types";
 import { decodeBinaryFrame } from "./hsWebSocketCodec";
 
+// `ws` delivers message data as `Buffer | ArrayBuffer | Buffer[]`. Normalize to Buffer
+// so downstream codec sees a consistent type.
+function toBuffer(data: WebSocket.RawData): Buffer {
+  if (Buffer.isBuffer(data)) return data;
+  if (Array.isArray(data)) return Buffer.concat(data);
+  return Buffer.from(data as ArrayBuffer);
+}
+
 /**
  * NeoWebSocket manages the market-data and order-feed WebSocket connections.
  * Mirrors the Python NeoWebSocket class.
@@ -85,7 +93,7 @@ export class NeoWebSocket {
         this.onOpen?.("market socket opened");
         resolve();
       });
-      ws.on("message", (data) => this.handleMarketMessage(data as Buffer));
+      ws.on("message", (data) => this.handleMarketMessage(toBuffer(data)));
       ws.on("error", (err) => {
         this.marketOpen = false;
         this.onError?.(err);
@@ -122,7 +130,7 @@ export class NeoWebSocket {
         this.onOpen?.("order feed opened");
         resolve();
       });
-      ws.on("message", (data) => this.handleOrderMessage(data as Buffer));
+      ws.on("message", (data) => this.handleOrderMessage(toBuffer(data)));
       ws.on("error", (err) => {
         this.orderOpen = false;
         this.onError?.(err);

--- a/client/typescript-client/src/websocket/hsWebSocketCodec.ts
+++ b/client/typescript-client/src/websocket/hsWebSocketCodec.ts
@@ -1,0 +1,25 @@
+// Binary frame parser for the HSM market-data WebSocket.
+// Mirrors the structural port in the Go client's hswebsocket.go.
+
+export interface DecodedFrame {
+  packet_type: number;
+  payload: Buffer;
+}
+
+export function decodeBinaryFrame(buf: Buffer): DecodedFrame[] {
+  if (buf.length < 1) return [];
+  const count = buf.readUInt8(0);
+  let pos = 1;
+  const out: DecodedFrame[] = [];
+  for (let i = 0; i < count; i++) {
+    if (pos + 2 > buf.length) break;
+    const pktLen = buf.readUInt16BE(pos);
+    pos += 2;
+    if (pos + pktLen > buf.length) break;
+    const payload = buf.slice(pos, pos + pktLen);
+    pos += pktLen;
+    if (payload.length < 1) continue;
+    out.push({ packet_type: payload.readUInt8(0), payload: payload.slice(1) });
+  }
+  return out;
+}

--- a/client/typescript-client/tsconfig.json
+++ b/client/typescript-client/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "moduleResolution": "node",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "examples/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Adds skeleton SDKs under `client/` for Go, Java, TypeScript, and .NET, mirroring the public surface of `neo_api_client`.

Closes #65